### PR TITLE
Bug fix: broken format string at line 1324

### DIFF
--- a/MFT.py
+++ b/MFT.py
@@ -1321,7 +1321,7 @@ class MFTEnumerator(object):
         for record, record_path in self.enumerate_paths():
             if lower_path == record_path.lower():
                 return record
-        raise KeyError("Path not found: " % path)
+        raise KeyError("Path not found: %s" % path)
 
 
 class MFTTreeNode(object):


### PR DESCRIPTION
Line 1324 in MFT.py handles the instances in which a file provided by the User is not found by the parser. The code for this is below along with its output, which throws a TypeError as the result of a broken format string:

raise KeyError("Path not found: " % path)

dev@computer:~/INDXParse$ python get_file_info.py ~/MFT "doesnotexist"
Traceback (most recent call last):
  File "get_file_info.py", line 416, in <module>
    main()
  File "get_file_info.py", line 412, in main
    record = enum.get_record_by_path(path)
  File "/home/dev/INDXParse/MFT.py", line 1324, in get_record_by_path
    raise KeyError("Path not found: " % path)
TypeError: not all arguments converted during string formatting

The proposed change at line 1324 in MFT.py:

raise KeyError("Path not found: %s" % path)

Results:

dev@computer:~/INDXParse$ python get_file_info.py ~/MFT "doesnotexist"
Traceback (most recent call last):
  File "get_file_info.py", line 416, in <module>
    main()
  File "get_file_info.py", line 412, in main
    record = enum.get_record_by_path(path)
  File "/home/dev/INDXParse/MFT.py", line 1324, in get_record_by_path
    raise KeyError("Path not found: %s" % path)
KeyError: 'Path not found: doesnotexist'



