### PR TITLE
Start type annotations

### DIFF
--- a/BinaryParser.py
+++ b/BinaryParser.py
@@ -817,7 +817,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_string(self, offset: int, length: int) -> bytes:
+    def unpack_string(self, offset: int, length: int):
         """
         Returns a string from the relative offset with the given length.
         Arguments:
@@ -828,7 +828,7 @@ class Block(object):
         """
         return self.unpack_binary(offset, length)
 
-    def unpack_wstring(self, offset: int, length: int) -> bytes:
+    def unpack_wstring(self, offset: int, length: int):
         """
         Returns a string from the relative offset with the given length,
         where each character is a wchar (2 bytes)

--- a/BinaryParser.py
+++ b/BinaryParser.py
@@ -838,11 +838,7 @@ class Block(object):
         Throws:
         - `UnicodeDecodeError`
         """
-        try:
-            return self._buf[self._offset + offset:self._offset + offset + \
-                             2 * length].tostring().decode("utf-16le")
-        except AttributeError: # already a 'str' ?
-            return self._buf[self._offset + offset:self._offset + offset + \
+        return self._buf[self._offset + offset:self._offset + offset + \
                              2 * length].decode("utf-16le")
 
     def unpack_dosdate(self, offset: int) -> datetime:

--- a/BinaryParser.py
+++ b/BinaryParser.py
@@ -326,7 +326,7 @@ class OverrunBufferException(ParseException):
             (self._value)
 
 
-def read_byte(buf, offset):
+def read_byte(buf: bytes, offset: int) -> int:
     """
     Returns a little-endian unsigned byte from the relative offset of the given buffer.
     Arguments:
@@ -341,7 +341,7 @@ def read_byte(buf, offset):
         raise OverrunBufferException(offset, len(buf))
 
 
-def read_word(buf, offset):
+def read_word(buf: bytes, offset: int) -> int:
     """
     Returns a little-endian unsigned word from the relative offset of the given buffer.
     Arguments:
@@ -356,7 +356,7 @@ def read_word(buf, offset):
         raise OverrunBufferException(offset, len(buf))
 
 
-def read_dword(buf, offset):
+def read_dword(buf: bytes, offset: int) -> int:
     """
     Returns a little-endian unsigned dword from the relative offset of the given buffer.
     Arguments:
@@ -622,7 +622,7 @@ class Block(object):
     def current_field_offset(self):
         return self._implicit_offset
 
-    def unpack_byte(self, offset):
+    def unpack_byte(self, offset: int) -> int:
         """
         Returns a little-endian unsigned byte from the relative offset.
         Arguments:
@@ -632,7 +632,7 @@ class Block(object):
         """
         return read_byte(self._buf, self._offset + offset)
 
-    def unpack_int8(self, offset):
+    def unpack_int8(self, offset: int) -> int:
         """
         Returns a little-endian signed byte from the relative offset.
         Arguments:
@@ -646,7 +646,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_word(self, offset):
+    def unpack_word(self, offset: int) -> int:
         """
         Returns a little-endian unsigned WORD (2 bytes) from the
           relative offset.
@@ -657,7 +657,7 @@ class Block(object):
         """
         return read_word(self._buf, self._offset + offset)
 
-    def unpack_word_be(self, offset):
+    def unpack_word_be(self, offset: int) -> int:
         """
         Returns a big-endian unsigned WORD (2 bytes) from the
           relative offset.
@@ -672,7 +672,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_int16(self, offset):
+    def unpack_int16(self, offset: int) -> int:
         """
         Returns a little-endian signed WORD (2 bytes) from the
           relative offset.
@@ -697,7 +697,7 @@ class Block(object):
         o = self._offset + offset
         return struct.pack_into("<H", self._buf, o, word)
 
-    def unpack_dword(self, offset):
+    def unpack_dword(self, offset: int) -> int:
         """
         Returns a little-endian DWORD (4 bytes) from the relative offset.
         Arguments:
@@ -707,7 +707,7 @@ class Block(object):
         """
         return read_dword(self._buf, self._offset + offset)
 
-    def unpack_dword_be(self, offset):
+    def unpack_dword_be(self, offset: int) -> int:
         """
         Returns a big-endian DWORD (4 bytes) from the relative offset.
         Arguments:
@@ -721,7 +721,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_int32(self, offset):
+    def unpack_int32(self, offset: int) -> int:
         """
         Returns a little-endian signed integer (4 bytes) from the
           relative offset.
@@ -736,7 +736,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_qword(self, offset):
+    def unpack_qword(self, offset: int) -> int:
         """
         Returns a little-endian QWORD (8 bytes) from the relative offset.
         Arguments:
@@ -750,7 +750,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_int64(self, offset):
+    def unpack_int64(self, offset: int) -> int:
         """
         Returns a little-endian signed 64-bit integer (8 bytes) from
           the relative offset.
@@ -765,7 +765,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_float(self, offset):
+    def unpack_float(self, offset: int) -> float:
         """
         Returns a single-precision float (4 bytes) from
           the relative offset.  IEEE 754 format.
@@ -780,7 +780,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_double(self, offset):
+    def unpack_double(self, offset: int) -> float:
         """
         Returns a double-precision float (8 bytes) from
           the relative offset.  IEEE 754 format.
@@ -813,7 +813,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_string(self, offset, length):
+    def unpack_string(self, offset: int, length: int) -> bytes:
         """
         Returns a string from the relative offset with the given length.
         Arguments:
@@ -824,7 +824,7 @@ class Block(object):
         """
         return self.unpack_binary(offset, length)
 
-    def unpack_wstring(self, offset, length):
+    def unpack_wstring(self, offset: int, length: int) -> bytes:
         """
         Returns a string from the relative offset with the given length,
         where each character is a wchar (2 bytes)
@@ -841,7 +841,7 @@ class Block(object):
             return self._buf[self._offset + offset:self._offset + offset + \
                              2 * length].decode("utf-16le")
 
-    def unpack_dosdate(self, offset):
+    def unpack_dosdate(self, offset: int) -> datetime:
         """
         Returns a datetime from the DOSDATE and DOSTIME starting at
         the relative offset.
@@ -856,7 +856,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_filetime(self, offset):
+    def unpack_filetime(self, offset: int):
         """
         Returns a datetime from the QWORD Windows timestamp starting at
         the relative offset.
@@ -887,7 +887,7 @@ class Block(object):
                                  parts[4], parts[5],
                                  parts[6], parts[7])
 
-    def unpack_guid(self, offset):
+    def unpack_guid(self, offset: int) -> str:
         """
         Returns a string containing a GUID starting at the relative offset.
         Arguments:

--- a/BinaryParser.py
+++ b/BinaryParser.py
@@ -867,7 +867,7 @@ class Block(object):
         """
         return parse_filetime(self.unpack_qword(offset))
 
-    def unpack_systemtime(self, offset):
+    def unpack_systemtime(self, offset: int) -> datetime:
         """
         Returns a datetime from the QWORD Windows SYSTEMTIME timestamp
           starting at the relative offset.
@@ -882,7 +882,7 @@ class Block(object):
             parts = struct.unpack_from("<WWWWWWWW", self._buf, o)
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
-        return datetime.datetime(parts[0], parts[1],
+        return datetime(parts[0], parts[1],
                                  parts[3],  # skip part 2 (day of week)
                                  parts[4], parts[5],
                                  parts[6], parts[7])

--- a/BinaryParser.py
+++ b/BinaryParser.py
@@ -799,7 +799,7 @@ class Block(object):
         except struct.error:
             raise OverrunBufferException(o, len(self._buf))
 
-    def unpack_binary(self, offset, length=False):
+    def unpack_binary(self, offset: int, length=0) -> bytes:
         """
         Returns raw binary data from the relative offset with the given length.
         Arguments:
@@ -810,7 +810,7 @@ class Block(object):
         - `OverrunBufferException`
         """
         if not length:
-            return ""
+            return b""
         o = self._offset + offset
         try:
             return struct.unpack_from("<%ds" % (length), self._buf, o)[0]

--- a/BinaryParser.py
+++ b/BinaryParser.py
@@ -238,30 +238,34 @@ def align(offset, alignment):
     return offset + (alignment - (offset % alignment))
 
 
-def dosdate(dosdate, dostime):
+def dosdate(dosdate: bytes, dostime: bytes) -> datetime:
     """
     `dosdate`: 2 bytes, little endian.
     `dostime`: 2 bytes, little endian.
     returns: datetime.datetime or datetime.datetime.min on error
     """
+    assert len(dosdate) == 2
+    assert len(dostime) == 2
+    t: int
+
     try:
-        t  = ord(dosdate[1]) << 8
-        t |= ord(dosdate[0])
+        t  = dosdate[1] << 8
+        t |= dosdate[0]
         day   = t & 0b0000000000011111
         month = (t & 0b0000000111100000) >> 5
         year  = (t & 0b1111111000000000) >> 9
         year += 1980
 
-        t  = ord(dostime[1]) << 8
-        t |= ord(dostime[0])
+        t  = dostime[1] << 8
+        t |= dostime[0]
         sec     = t & 0b0000000000011111
         sec    *= 2
         minute  = (t & 0b0000011111100000) >> 5
         hour    = (t & 0b1111100000000000) >> 11
 
-        return datetime.datetime(year, month, day, hour, minute, sec)
+        return datetime(year, month, day, hour, minute, sec)
     except:
-        return datetime.datetime.min
+        return datetime.min
 
 
 def parse_filetime(qword):

--- a/Progress.py
+++ b/Progress.py
@@ -54,7 +54,7 @@ class NullProgress(Progress):
 
 class ProgressBarProgress(Progress):
     def __init__(self, max_):
-        from progressbar import ETA, Bar, ProgressBar
+        from progressbar import ETA, Bar, ProgressBar  # type: ignore
         super(ProgressBarProgress, self).__init__(max_)
 
         widgets = ["Progress: ",

--- a/Progress.py
+++ b/Progress.py
@@ -54,7 +54,7 @@ class NullProgress(Progress):
 
 class ProgressBarProgress(Progress):
     def __init__(self, max_):
-        from progressbar import Bar
+        from progressbar import Bar # type: ignore
         from progressbar import ETA
         from progressbar import ProgressBar
         super(ProgressBarProgress, self).__init__(max_)


### PR DESCRIPTION
Disclaimer: Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.

The goal of this patch series is to improve type safety amongst core functions in the codebase and introduce support for static type review.

The first patch set enables a baseline state of mypy review where mypy raises no errors when reviewing the use of two INDXParse scripts.

The modifications made were tested with the following:

```bash
mypy list_mft.py MFTINDX.py
```

Status:
* Once the first patch should be accepted, `mypy` as called above passes.
* The patch removes some use of the `ord` function to handle the transition from python2 to python3.
* The patch successfully identifies and resolves one general bug form, pertaining to inconsistent use of the `datetime` module's functions.
* Each patch after the first continues to have `mypy` as called above pass.
* So far, the code has been type annotated for the `unpack_*`, `read_*`, and `dosdate` functions in `BinaryParser` with the exception of `unpack_filetime`.
   - The original intent of the function, with regards to returning `None` or `datetime` in the case of "null"-like input for `parse_filetime`, is unclear to us.
   - Dynamic code review is currently needed to understand expected behavior throughout the `INDXParse` codebase due to how `unpack_filetime` is set up to be called by `declare_field`.

Each patch log message describes its purpose.