### PR TITLE
Correct `def` to `class` for `INDEX_ROOT`

### DIFF
--- a/MFT.py
+++ b/MFT.py
@@ -335,7 +335,7 @@ class INDEX(Block, Nestable):
             pass
 
 
-def INDEX_ROOT(Block, Nestable):
+class INDEX_ROOT(Block, Nestable):
     def __init__(self, buf, offset, parent):
         super(INDEX_ROOT, self).__init__(buf, offset)
         self.declare_field("dword", "type", 0x0)


### PR DESCRIPTION
The one patch's log message describes its purpose.