### PR TITLE
Add return type annotation to `unpack_wstring`

### DIFF
--- a/BinaryParser.py
+++ b/BinaryParser.py
@@ -827,7 +827,7 @@ class Block(object):
         """
         return self.unpack_binary(offset, length)
 
-    def unpack_wstring(self, offset: int, length: int):
+    def unpack_wstring(self, offset: int, length: int) -> str:
         """
         Returns a string from the relative offset with the given length,
         where each character is a wchar (2 bytes)


### PR DESCRIPTION
Disclaimer: Participation by NIST in the creation of the documentation
of mentioned software is not intended to imply a recommendation or
endorsement by the National Institute of Standards and Technology, nor
is it intended to imply that any specific software is necessarily the
best available for the purpose.

The one patch's log message describes its purpose.