### PR TITLE
Convert two strings to bytestings

### DIFF
--- a/get_file_info.py
+++ b/get_file_info.py
@@ -13,11 +13,11 @@ from MFT import (ATTR_TYPE, MREF, MSEQNO, Attribute, Cache, FilenameAttribute,
                  IndexRootHeader, MFTEnumerator,
                  StandardInformationFieldDoesNotExist)
 
-ASCII_BYTE = " !\"#\$%&\'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}\\\~"
+ASCII_BYTE = b" !\"#\$%&\'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}\\\~"
 
 
 def ascii_strings(buf, n=4):
-    reg = "([%s]{%d,})" % (ASCII_BYTE, n)
+    reg = b"([%s]{%d,})" % (ASCII_BYTE, n)
     ascii_re = re.compile(reg)
     for match in ascii_re.finditer(buf):
         if isinstance(match.group(), array.array):


### PR DESCRIPTION
The patch converts two strings to `bytes` in `get_file_info.py`. The regular expression, `reg` in `ascii_strings` of `get_file_info.py` is looking through `buf`, which was previously annotated as `bytes`, meaning that `reg` needs to be `bytes`. Note the following example with inlined comments.

`t` substitutes for `reg`, `exp` for `ascii_re`, and `test` for `buf`

```
    # String buffer and string regex
    >>> import re
    >>> t = "t"
    >>> test = "test"
    >>> exp = re.compile(t)
    >>> for match in exp.finditer(test):
    ...     print(match)
    ...
    <re.Match object; span=(0, 1), match='t'>
    <re.Match object; span=(3, 4), match='t'>

    # Current code state
    >>> test = b"test"
    >>> for match in reg.finditer(test):
    ...     print(match)
    ...
    Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    TypeError: cannot use a string pattern on a bytes-like object

    # Modified code state
    >>> test = b"test"
    >>> t = b"t"
    >>> exp = re.compile(t)
    >>> for match in exp.finditer(test):
    ...     print(match)
    ...
    <re.Match object; span=(0, 1), match=b't'>
    <re.Match object; span=(3, 4), match=b't'>
```

The patch is written to pass mypy static type review when tested with the following:
```bash
    mypy list_mft.py MFTINDX.py
```

References:
* https://docs.python.org/3/library/re.html#re.finditer