### PR TITLE
Implement `logging` module in `MFTINDX`

### DIFF
--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -25,7 +25,7 @@
 #   Version v.1.2.0
 import calendar
 
-from indxparse.BinaryParser import debug, error, info, warning
+from indxparse.BinaryParser import debug, error, warning
 from indxparse.MFT import *
 
 verbose = False
@@ -650,7 +650,7 @@ def main():
 
     if results.filetype and results.filetype != "auto":
         results.filetype = results.filetype[0].lower()
-        info("Asked to process a file with type: " + results.filetype)
+        logging.info("Asked to process a file with type: " + results.filetype)
     else:
         with open(results.filename, "rb") as f:
             b = f.read(1024)
@@ -660,76 +660,76 @@ def main():
                 results.filetype = "indx"
             else:
                 results.filetype = "image"
-        info("Auto-detected input file type: " + results.filetype)
+        logging.info("Auto-detected input file type: " + results.filetype)
 
     if results.clustersize:
         results.clustersize = results.clustersize[0]
-        info(
+        logging.info(
             "Using explicit file system cluster size %s (%s) bytes"
             % (str(results.clustersize), hex(results.clustersize))
         )
     else:
         results.clustersize = 4096
-        info(
+        logging.info(
             "Assuming file system cluster size %s (%s) bytes"
             % (str(results.clustersize), hex(results.clustersize))
         )
 
     if results.offset:
         results.offset = results.offset[0]
-        info(
+        logging.info(
             "Using explicit volume offset %s (%s) bytes"
             % (str(results.offset), hex(results.offset))
         )
     else:
         results.offset = 32256
-        info(
+        logging.info(
             "Assuming volume offset %s (%s) bytes"
             % (str(results.offset), hex(results.offset))
         )
 
     if results.prefix:
         results.prefix = results.prefix[0]
-        info("Using path prefix " + results.prefix)
+        logging.info("Using path prefix " + results.prefix)
 
     if results.indxlist:
-        info("Asked to list entries in INDX records")
+        logging.info("Asked to list entries in INDX records")
         if results.filetype == "mft":
-            info(
+            logging.info(
                 "  Note, only resident INDX records can be processed "
                 "with an MFT input file"
             )
-            info(
+            logging.info(
                 "  If you find an interesting record, "
                 "use -i to identify the relevant INDX record clusters"
             )
         elif results.filetype == "indx":
-            info("  Note, only records in this INDX record will be listed")
+            logging.info("  Note, only records in this INDX record will be listed")
         elif results.filetype == "image":
             pass
         else:
             pass
 
     if results.slack:
-        info("Asked to list slack entries in INDX records")
-        info(
+        logging.info("Asked to list slack entries in INDX records")
+        logging.info(
             "  Note, this uses a scanning heuristic to identify records. "
             "These records may be corrupt or out-of-date."
         )
 
     if results.mftlist:
-        info("Asked to list active file entries in the MFT")
+        logging.info("Asked to list active file entries in the MFT")
         if results.filetype == "indx":
             error("Cannot list MFT entries of an INDX record")
 
     if results.deleted:
-        info("Asked to list deleted file entries in the MFT")
+        logging.info("Asked to list deleted file entries in the MFT")
         if results.filetype == "indx":
             error("Cannot list MFT entries of an INDX record")
 
     if results.infomode:
         results.infomode = results.infomode[0]
-        info("Asked to list information about path " + results.infomode)
+        logging.info("Asked to list information about path " + results.infomode)
         if results.indxlist or results.slack or results.mftlist or results.deleted:
             error(
                 "Information mode (-i) cannot be run "
@@ -738,7 +738,7 @@ def main():
 
         if results.extract:
             results.extract = results.extract[0]
-            info(
+            logging.info(
                 "Asked to extract INDX_ALLOCATION attribute "
                 "for the path " + results.infomode
             )
@@ -760,7 +760,7 @@ def main():
 
     if results.filter:
         results.filter = results.filter[0]
-        info(
+        logging.info(
             "Asked to only list file entry information "
             "for paths matching the regular expression: " + results.filter
         )

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -25,7 +25,6 @@
 #   Version v.1.2.0
 import calendar
 
-from indxparse.BinaryParser import debug, error, warning
 from indxparse.MFT import *
 
 verbose = False
@@ -229,7 +228,9 @@ def try_write(s):
     try:
         sys.stdout.write(s)
     except (UnicodeEncodeError, UnicodeDecodeError):
-        warning("Failed to write string " "due to encoding issue: " + str(list(s)))
+        logging.warning(
+            "Failed to write string " "due to encoding issue: " + str(list(s))
+        )
 
 
 def print_nonresident_indx_bodyfile(options, buf, basepath=""):
@@ -258,15 +259,17 @@ def print_bodyfile(options):
         if options.filter:
             refilter = re.compile(options.filter)
         for record in f.record_generator():
-            debug("Considering MFT record %s" % (record.mft_record_number()))
+            logging.debug("Considering MFT record %s" % (record.mft_record_number()))
             try:
                 if record.magic() != 0x454C4946:
-                    debug("Record has a bad magic value")
+                    logging.debug("Record has a bad magic value")
                     continue
                 if options.filter:
                     path = f.mft_record_build_path(record, {})
                     if not refilter.search(path):
-                        debug("Skipping listing path " "due to regex filter: " + path)
+                        logging.debug(
+                            "Skipping listing path " "due to regex filter: " + path
+                        )
                         continue
                 if record.is_active() and options.mftlist:
                     try_write(record_bodyfile(f, record))
@@ -720,18 +723,18 @@ def main():
     if results.mftlist:
         logging.info("Asked to list active file entries in the MFT")
         if results.filetype == "indx":
-            error("Cannot list MFT entries of an INDX record")
+            logging.error("Cannot list MFT entries of an INDX record")
 
     if results.deleted:
         logging.info("Asked to list deleted file entries in the MFT")
         if results.filetype == "indx":
-            error("Cannot list MFT entries of an INDX record")
+            logging.error("Cannot list MFT entries of an INDX record")
 
     if results.infomode:
         results.infomode = results.infomode[0]
         logging.info("Asked to list information about path " + results.infomode)
         if results.indxlist or results.slack or results.mftlist or results.deleted:
-            error(
+            logging.error(
                 "Information mode (-i) cannot be run "
                 "with file entry list modes (-l/-s/-m/-d)"
             )
@@ -744,10 +747,14 @@ def main():
             )
 
     if results.extract and not results.infomode:
-        warning("Extract (-e) doesn't make sense " "without information mode (-i)")
+        logging.warning(
+            "Extract (-e) doesn't make sense " "without information mode (-i)"
+        )
 
     if results.extract and not results.filetype == "image":
-        error("Cannot extract non-resident attributes " "from anything but an image")
+        logging.error(
+            "Cannot extract non-resident attributes " "from anything but an image"
+        )
 
     if not (
         results.indxlist
@@ -756,7 +763,7 @@ def main():
         or results.deleted
         or results.infomode
     ):
-        error("You must choose a mode (-i/-l/-s/-m/-d)")
+        logging.error("You must choose a mode (-i/-l/-s/-m/-d)")
 
     if results.filter:
         results.filter = results.filter[0]
@@ -765,7 +772,7 @@ def main():
             "for paths matching the regular expression: " + results.filter
         )
         if results.infomode:
-            warning("This filter has no meaning with information mode (-i)")
+            logging.warning("This filter has no meaning with information mode (-i)")
 
     if results.infomode:
         print_indx_info(results)


### PR DESCRIPTION
Disclaimer: Participation by NIST in the creation of the documentation
of mentioned software is not intended to imply a recommendation or
endorsement by the National Institute of Standards and Technology, nor
is it intended to imply that any specific software is necessarily the
best available for the purpose.

The PR starts with correcting a `TypeError` caused by the `info` variable name. a34ebafd unifies the `logging` practice with the standard library. 

Each patch's log message describes its purpose.