### PR TITLE
Start `mypy` static code review via Makefile framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,5 @@ jobs:
       run: |
         pip -q install pre-commit
         pre-commit run --all-files
+    - name: Run tests
+      run: make PYTHON3=python check

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.egg-info
 *.zip
 .idea/*
+.venv.done.log
 build
+venv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+#!/usr/bin/make -f
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties.  Pursuant to Title 17 Seciton 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States.  NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+PYTHON3 ?= python3
+
+all:
+
+.PHONY: \
+  check-mypy
+
+.venv.done.log: \
+  setup.cfg \
+  setup.py
+	rm -rf venv
+	$(PYTHON3) -m venv venv
+	source venv/bin/activate \
+	  && pip install \
+	    --upgrade \
+	    pip \
+	    setuptools \
+	    wheel
+	source venv/bin/activate \
+	  && pip install \
+	    --editable \
+	    .[testing]
+	touch $@
+
+check: \
+  check-mypy
+
+check-mypy: \
+  .venv.done.log
+	source venv/bin/activate \
+	  && mypy \
+	    indxparse/MFTINDX.py \
+	    indxparse/list_mft.py
+
+clean:
+	@rm -f \
+	  .venv.done.log

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ console_scripts =
 [options.extras_require]
 fuse =
     fuse-python
+testing =
+    mypy
 wx =
     wxPython
 


### PR DESCRIPTION
_Disclaimer_: Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.

Issues #38 and #41 began discussions on a testing framework that would eventually include static type review.

Work done recently with @sldouglas-nist has been adding type signatures. Testing of each submitted pull request has included a manual run of `mypy` against some objective script files within INDXParse.

This patch begins automating the review of type signatures, following the results of some discussions on Issue 38 - namely, use of Make.  Make is used for the static type review, intentionally instead of `pre-commit`, due to a certain behavior that could arise: If `pre-commit` encounters any failure that it can't automatically fix, the user in their local editing environment is prevented from completing the `git commit` command.  A change to a type signature can have a wide- ranging effect, and this patch is added to prevent that user-experience. (Some of this has been discussed at further length in `case-utils` PR 37, where `pre-commit` was added to another project.)

The Makefile added in this patch runs `mypy` review over selected files analyzed to date, with the expectation that eventually the command will become `mypy indxparse`, not enumerating specific files.  The GitHub Action is updated to include `make check` (parameterized for the runner's selected Python) as the last step run.

The Makefile also confirms that the package installs in a Python 3 virtual environment, and incorporates the `mypy` package through a new feature, `testing`.

References:
* https://github.com/casework/CASE-Utilities-Python/pull/37
* https://github.com/williballenthin/INDXParse/issues/38
* https://github.com/williballenthin/INDXParse/issues/41