### PR TITLE
Correct `bytes` against `str` comparison

### DIFF
--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -657,9 +657,9 @@ def main():
     else:
         with open(results.filename, "rb") as f:
             b = f.read(1024)
-            if b[0:4] == "FILE":
+            if b[0:4] == b"FILE":
                 results.filetype = "mft"
-            elif b[0:4] == "INDX":
+            elif b[0:4] == b"INDX":
                 results.filetype = "indx"
             else:
                 results.filetype = "image"


### PR DESCRIPTION
Disclaimer: Participation by NIST in the creation of the documentation
of mentioned software is not intended to imply a recommendation or
endorsement by the National Institute of Standards and Technology, nor
is it intended to imply that any specific software is necessarily the
best available for the purpose.

The one patch's log message describes its purpose.