### PR TITLE
Remove reliance on `options` namespace in `MFT.py`

### DIFF
--- a/indxparse/MFT.py
+++ b/indxparse/MFT.py
@@ -1283,23 +1283,24 @@ class MFTRecord(FixupBlock):
 
 
 class NTFSFile:
-    def __init__(self, options):
-        if type(options) == dict:
-            self.filename = options["filename"]
-            self.filetype = options["filetype"] or "mft"
-            self.offset = options["offset"] or 0
-            self.clustersize = options["clustersize"] or 4096
-            self.mftoffset = False
-            self.prefix = options["prefix"] or None
-            self.progress = options["progress"]
-        else:
-            self.filename = options.filename
-            self.filetype = options.filetype
-            self.offset = options.offset
-            self.clustersize = options.clustersize
-            self.mftoffset = False
-            self.prefix = options.prefix
-            self.progress = options.progress
+    def __init__(
+        self,
+        *args: typing.Any,
+        clustersize: int = 4096,
+        filename: str,
+        filetype: str,
+        offset: int = 0,
+        prefix: str,
+        progress: bool = False,
+        **kwargs: typing.Any
+    ) -> None:
+        self.clustersize = clustersize
+        self.filename = filename
+        self.filetype = filetype
+        self.offset = offset
+        self.mftoffset = False
+        self.prefix = prefix or None
+        self.progress = progress
 
     # TODO calculate cluster size
 

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -255,7 +255,14 @@ def print_nonresident_indx_bodyfile(options, buf, basepath=""):
 
 def print_bodyfile(options):
     if options.filetype == "mft" or options.filetype == "image":
-        f = NTFSFile(options)
+        f = NTFSFile(
+            clustersize=options.clustersize,
+            filename=options.filename,
+            filetype=options.filetype,
+            offset=options.offset,
+            prefix=options.prefix,
+            progress=options.progress,
+        )
         if options.filter:
             refilter = re.compile(options.filter)
         for record in f.record_generator():
@@ -305,7 +312,14 @@ def print_bodyfile(options):
 
 
 def print_indx_info(options):
-    f = NTFSFile(options)
+    f = NTFSFile(
+        clustersize=options.clustersize,
+        filename=options.filename,
+        filetype=options.filetype,
+        offset=options.offset,
+        prefix=options.prefix,
+        progress=options.progress,
+    )
     try:
         record_num = int(options.infomode)
         record_buf = f.mft_get_record_buf(record_num)

--- a/indxparse/MFTView.py
+++ b/indxparse/MFTView.py
@@ -179,14 +179,12 @@ class AppModel(wx.EvtHandler):
             f.seek(0)
 
         f = NTFSFile(
-            {
-                "filename": self._filename,
-                "filetype": "mft",
-                "offset": 0,
-                "clustersize": 4096,
-                "prefix": "C:",
-                "progress": False,
-            }
+            clustersize=4096,
+            filename=self._filename,
+            filetype="mft",
+            offset=0,
+            prefix="C:",
+            progress=False,
         )
 
         class RecordConflict(Exception):
@@ -1360,14 +1358,12 @@ class MFTFileView(wx.Panel):
         rec_num = self._tree.GetPyData(item)["rec_num"]
 
         f = NTFSFile(
-            {
-                "filename": self._filename,
-                "filetype": "mft",
-                "offset": 0,
-                "clustersize": 4096,
-                "prefix": "C:",
-                "progress": False,
-            }
+            clustersize=4096,
+            filename=self._filename,
+            filetype="mft",
+            offset=0,
+            prefix="C:",
+            progress=False,
         )
 
         try:


### PR DESCRIPTION
Disclaimer: Participation by NIST in the creation of the documentation
of mentioned software is not intended to imply a recommendation or
endorsement by the National Institute of Standards and Technology, nor
is it intended to imply that any specific software is necessarily the
best available for the purpose.

The one patch's log message describes its purpose.