### PR TITLE
Designate INDXParse as a typed project and review package source tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,7 @@ check-mypy: \
   .venv.done.log
 	source venv/bin/activate \
 	  && mypy \
-	    indxparse/MFTINDX.py \
-	    indxparse/list_mft.py
+	    indxparse
 
 check-third_party:
 	$(MAKE) \

--- a/indxparse/INDXFind.py
+++ b/indxparse/INDXFind.py
@@ -18,6 +18,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+#
+#
+#   Alex Nelson, NIST, contributed to this file.  Contributions of NIST
+#   are not subject to US Copyright.
 
 import sys
 
@@ -29,9 +33,11 @@ if sys.argv[1] == "-h":
 f = open(
     sys.argv[1], "rb"
 )  # ewfmount'd drive expected as first argument on command line
-indxBytes = "494e445828000900"  # 49 4e 44 58 28 00 09 00  "INDX( header"
+indxBytes = (
+    b"\x49\x4e\x44\x58\x28\x00\x09\x00"  # 49 4e 44 58 28 00 09 00  "INDX( header"
+)
 offset = 0  # data processed
-byteChunk = "go"  # cheap do-while
+byteChunk = b"go"  # cheap do-while
 recordsFound = 0  # for progress
 outFile = open("INDX_records.raw", "wb")  # output file
 
@@ -41,12 +47,12 @@ print(
     "\tINDX_records.raw should be parsed with INDXparser.py which can be found at:\thttps://github.com/williballenthin/INDXParse\n"
 )
 
-while byteChunk != "":
+while byteChunk != b"":
     byteChunk = f.read(
         4096
     )  # Only searching for cluster aligned (4096 on Windows Server 2003) INDX records... records all appear to be 4096 bytes
     compare = byteChunk[0:8]  # Compare INDX header to first 8 bytes of the byteChunk
-    if compare.encode("hex") == indxBytes:
+    if compare == indxBytes:
         recordsFound = recordsFound + 1
         outFile.write(byteChunk)  # Write the byteChunk to the output file
 

--- a/indxparse/MFTView.py
+++ b/indxparse/MFTView.py
@@ -27,10 +27,10 @@ import array
 import re
 import sys
 
-import wx
-import wx.lib.newevent
-import wx.lib.scrolledpanel as scrolled
-from wx.lib.evtmgr import eventManager
+import wx  # type: ignore
+import wx.lib.newevent  # type: ignore
+import wx.lib.scrolledpanel as scrolled  # type: ignore
+from wx.lib.evtmgr import eventManager  # type: ignore
 
 from indxparse.MFT import (
     ATTR_TYPE,

--- a/indxparse/fuse-mft.py
+++ b/indxparse/fuse-mft.py
@@ -11,7 +11,7 @@ import os
 import stat
 import sys
 
-from fuse import FUSE, FuseOSError, Operations, fuse_get_context
+from fuse import FUSE, FuseOSError, Operations, fuse_get_context  # type: ignore
 
 from indxparse.BinaryParser import Mmap
 from indxparse.get_file_info import format_record

--- a/indxparse/py.typed
+++ b/indxparse/py.typed
@@ -1,0 +1,5 @@
+# Alex Nelson, NIST, contributed to this file.  Contributions of NIST
+# are not subject to US Copyright.
+
+# This file is defined to support PEP 561:
+# https://www.python.org/dev/peps/pep-0561/

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,9 @@ testing =
 wx =
     wxPython
 
+[options.package_data]
+indxparse = py.typed
+
 [isort]
 # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html
 profile = black


### PR DESCRIPTION
This Pull Request provides support for the eventual goal of running `mypy` as part of Continuous Integration, as noted in #38.

The 2nd patch describes the addition of a `py.typed` file, which turns INDXParse into being considered a typed project.  If this 2nd patch were applied directly to the `master` branch from when this PR was initially drafted (`768430b`), some type errors would arise when running this command:

```bash
mypy indxparse
```

The 1st patch fixes those errors preemptively.

The 3rd patch expands `mypy` review to the package's source tree (i.e. `${top_srcdir}/indxparse`), rather than focusing on the initial two scripts @sldouglas-nist and I were reviewing.  I believe this does **not** meet #38's goal of full type checking of the project, as `mypy --strict` still raises around 1,600 errors.  (At a glance, a good chunk of these look like they would be fixed dozens at a time per line of fixed code, so this does not necessarily imply over 1,000 fixes are needed.)   While not sufficient, I do think it's necessary:  enabling type review over the source tree now should prevent type-based regressions going forward.

Meanwhile, adding `py.typed` (coming back to patch 2) provides a benefit to downstream consumers of INDXParse that use it as an imported package.  I'm drafting a functionality extension that will need to live in its own repository for at least a little while.  That repository reviews with `mypy --strict`, and stumbled into the need for `py.typed` when it took its first peek into the `indxparse.MFT` module.  For the benefit of any other projects that (1) import INDXParse as a package, and (2) type-review their code, adding `py.typed` potentially kickstarts a review dialogue that will help prioritize attention on the current typing errors.

References:
* https://github.com/williballenthin/INDXParse/issues/38

Disclaimer:
Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.