### PR TITLE
Review `MFTINDX.py` with `mypy --strict`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ check-mypy: \
 	source venv/bin/activate \
 	  && mypy \
 	    indxparse
+	source venv/bin/activate \
+	  && mypy \
+	    --strict \
+	    indxparse/MFTINDX.py
 
 check-third_party:
 	$(MAKE) \

--- a/indxparse/MFT.py
+++ b/indxparse/MFT.py
@@ -501,6 +501,7 @@ class NTATTR_STANDARD_INDEX_HEADER(Block):
         self.entry_list_start: typing.Callable[[], int]
 
         self.declare_field("dword", "entry_list_end")
+        self.entry_list_end: typing.Callable[[], int]
 
         self.declare_field("dword", "entry_list_allocation_end")
         self.entry_list_allocation_end: typing.Callable[[], int]
@@ -514,7 +515,7 @@ class NTATTR_STANDARD_INDEX_HEADER(Block):
             self.entry_list_allocation_end() - self.entry_list_start(),
         )
 
-    def entries(self):
+    def entries(self) -> typing.Iterator[IndexEntry]:
         """
         A generator that returns each INDX entry associated with this node.
         """
@@ -528,7 +529,7 @@ class NTATTR_STANDARD_INDEX_HEADER(Block):
             offset += e.length()
             yield e
 
-    def slack_entries(self):
+    def slack_entries(self) -> typing.Iterator[SlackIndexEntry]:
         """
         A generator that yields INDX entries found in the slack space
         associated with this header.
@@ -569,7 +570,7 @@ class IndexRootHeader(Block):
         self.declare_field("byte", "unused3")
         self._node_header_offset = self.current_field_offset()
 
-    def node_header(self):
+    def node_header(self) -> NTATTR_STANDARD_INDEX_HEADER:
         return NTATTR_STANDARD_INDEX_HEADER(
             self._buf, self.offset() + self._node_header_offset, self
         )
@@ -586,6 +587,7 @@ class IndexRecordHeader(FixupBlock):
         super(IndexRecordHeader, self).__init__(buf, offset, parent)
 
         self.declare_field("dword", "magic", 0x0)
+        self.magic: typing.Callable[[], int]
 
         self.declare_field("word", "usa_offset")
         self.usa_offset: typing.Callable[[], int]
@@ -600,7 +602,7 @@ class IndexRecordHeader(FixupBlock):
         self._node_header_offset = self.current_field_offset()
         self.fixup(self.usa_count(), self.usa_offset())
 
-    def node_header(self):
+    def node_header(self) -> NTATTR_STANDARD_INDEX_HEADER:
         return NTATTR_STANDARD_INDEX_HEADER(
             self._buf, self.offset() + self._node_header_offset, self
         )
@@ -669,6 +671,7 @@ class IndexEntry(Block):
         self.declare_field("qword", "mft_reference", 0x0)
 
         self.declare_field("word", "length")
+        self.length: typing.Callable[[], int]
 
         self.declare_field("word", "filename_information_length")
         self.filename_information_length: typing.Callable[[], int]
@@ -681,12 +684,13 @@ class IndexEntry(Block):
             self.current_field_offset(),
             self.filename_information_length(),
         )
+        self._off_filename_information_buffer: int
 
         self.declare_field(
             "qword", "child_vcn", align(self.current_field_offset(), 0x8)
         )
 
-    def filename_information(self):
+    def filename_information(self) -> FilenameAttribute:
         return FilenameAttribute(
             self._buf, self.offset() + self._off_filename_information_buffer, self
         )
@@ -724,6 +728,7 @@ class StandardInformation(Block):
         self.accessed_time: typing.Callable[[], datetime]
 
         self.declare_field("dword", "attributes")
+        self.attributes: typing.Callable[[], int]
 
         self.declare_field("binary", "reserved", self.current_field_offset(), 0xC)
 
@@ -741,7 +746,7 @@ class StandardInformation(Block):
     # def __len__(self):
     #    return 0x42 + (self.filename_length() * 2)
 
-    def owner_id(self):
+    def owner_id(self) -> int:
         """
         This is an explicit method because it may not exist in OSes under Win2k
 
@@ -763,7 +768,7 @@ class StandardInformation(Block):
         except OverrunBufferException:
             raise StandardInformationFieldDoesNotExist("Security ID")
 
-    def quota_charged(self):
+    def quota_charged(self) -> int:
         """
         This is an explicit method because it may not exist in OSes under Win2k
 
@@ -774,7 +779,7 @@ class StandardInformation(Block):
         except OverrunBufferException:
             raise StandardInformationFieldDoesNotExist("Quota Charged")
 
-    def usn(self):
+    def usn(self) -> int:
         """
         This is an explicit method because it may not exist in OSes under Win2k
 
@@ -812,11 +817,13 @@ class FilenameAttribute(Block, Nestable):
         self.accessed_time: typing.Callable[[], datetime]
 
         self.declare_field("qword", "physical_size")
+        self.physical_size: typing.Callable[[], int]
 
         self.declare_field("qword", "logical_size")
         self.logical_size: typing.Callable[[], int]
 
         self.declare_field("dword", "flags")
+        self.flags: typing.Callable[[], int]
 
         self.declare_field("dword", "reparse_value")
 
@@ -902,10 +909,12 @@ class Runentry(Block, Nestable):
         self.declare_field(
             "binary", "length_binary", self.current_field_offset(), self._length_length
         )
+        self.length_binary: typing.Callable[[], array.array]
 
         self.declare_field(
             "binary", "offset_binary", self.current_field_offset(), self._offset_length
         )
+        self.offset_binary: typing.Callable[[], array.array]
 
     @staticmethod
     def structure_size(
@@ -948,11 +957,11 @@ class Runentry(Block, Nestable):
             ret *= -1
         return ret
 
-    def offset(self):
+    def offset(self) -> int:
         # TODO(wb): make this run_offset
         return self.lsb2signednum(self.offset_binary())
 
-    def length(self):
+    def length(self) -> int:
         # TODO(wb): make this run_offset
         return self.lsb2num(self.length_binary())
 
@@ -985,7 +994,7 @@ class Runlist(Block):
     def __len__(self):
         return sum(map(len, self._entries()))
 
-    def _entries(self, length=None):
+    def _entries(self, length: typing.Optional[int] = None) -> typing.List[Runentry]:
         ret = []
         offset = self.offset()
         entry = Runentry(self._buf, offset, self)
@@ -999,7 +1008,7 @@ class Runlist(Block):
             entry = Runentry(self._buf, offset, self)
         return ret
 
-    def runs(self, length=None):
+    def runs(self, length=None) -> typing.Iterator[typing.Tuple[int, int]]:
         """
         Yields tuples (volume offset, length).
         Recall that the entries are relative to one another
@@ -1085,6 +1094,7 @@ class Attribute(Block, Nestable):
         self.name_offset: typing.Callable[[], int]
 
         self.declare_field("word", "flags")
+        self.flags: typing.Callable[[], int]
 
         self.declare_field("word", "instance")
 
@@ -1094,6 +1104,7 @@ class Attribute(Block, Nestable):
             self.declare_field("qword", "highest_vcn")
 
             self.declare_field("word", "runlist_offset")
+            self.runlist_offset: typing.Callable[[], int]
 
             self.declare_field("byte", "compression_unit")
 
@@ -1108,6 +1119,7 @@ class Attribute(Block, Nestable):
             self.declare_field("byte", "reserved5")
 
             self.declare_field("qword", "allocated_size")
+            self.allocated_size: typing.Callable[[], int]
 
             self.declare_field("qword", "data_size")
             self.data_size: typing.Callable[[], int]
@@ -1144,7 +1156,7 @@ class Attribute(Block, Nestable):
     def __len__(self):
         return self.size()
 
-    def runlist(self):
+    def runlist(self) -> Runlist:
         return Runlist(self._buf, self.offset() + self.runlist_offset(), self)
 
     def size(self):
@@ -1160,14 +1172,14 @@ class MFT_RECORD_FLAGS:
     MFT_RECORD_IS_DIRECTORY = 0x2
 
 
-def MREF(mft_reference):
+def MREF(mft_reference) -> int:
     """
     Given a MREF/mft_reference, return the record number part.
     """
     return mft_reference & 0xFFFFFFFFFFFF
 
 
-def MSEQNO(mft_reference):
+def MSEQNO(mft_reference) -> int:
     """
     Given a MREF/mft_reference, return the sequence number part.
     """
@@ -1242,10 +1254,11 @@ class MFTRecord(FixupBlock):
             offset += len(a)
             yield a
 
-    def attribute(self, attr_type):
+    def attribute(self, attr_type) -> typing.Optional[Attribute]:
         for a in self.attributes():
             if a.type() == attr_type:
                 return a
+        return None
 
     def is_directory(self) -> bool:
         return bool(self.flags() & MFT_RECORD_FLAGS.MFT_RECORD_IS_DIRECTORY)
@@ -1283,6 +1296,8 @@ class MFTRecord(FixupBlock):
     def standard_information(self) -> typing.Optional[StandardInformation]:
         try:
             attr = self.attribute(ATTR_TYPE.STANDARD_INFORMATION)
+            if attr is None:
+                return None
             return StandardInformation(attr.value(), 0, self)
         except AttributeError:
             return None
@@ -1463,7 +1478,7 @@ class NTFSFile:
         cycledetector[rec_num] = True
         return self.mft_record_build_path(parent, cycledetector) + "\\" + fn.filename()
 
-    def mft_get_record_by_path(self, path):
+    def mft_get_record_by_path(self, path) -> typing.Optional[MFTRecord]:
         # TODO could optimize here by trying to use INDX buffers
         # and actually walk through the FS
         count = -1
@@ -1477,9 +1492,9 @@ class NTFSFile:
             if record_path.lower() != path.lower():
                 continue
             return record
-        return False
+        return None
 
-    def read(self, offset, length):
+    def read(self, offset, length) -> array.array:
         if self.filetype == "image":
             with open(self.filename, "rb") as f:
                 f.seek(offset)

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -30,7 +30,7 @@ import logging
 import re
 import sys
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from indxparse.BinaryParser import OverrunBufferException
 from indxparse.MFT import (
@@ -245,7 +245,7 @@ def record_indx_entries_bodyfile(options, ntfsfile, record):
     return ret
 
 
-def try_write(s):
+def try_write(s: str) -> None:
     try:
         sys.stdout.write(s)
     except (UnicodeEncodeError, UnicodeDecodeError):
@@ -385,7 +385,7 @@ def print_indx_info(options):
             if rfni is not None:
                 print("  size: %d bytes" % (rfni.logical_size()))
 
-    def get_flags(flags):
+    def get_flags(flags) -> List[str]:
         attributes = []
         if flags & 0x01:
             attributes.append("readonly")

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -30,6 +30,7 @@ import logging
 import re
 import sys
 from datetime import datetime
+from typing import Optional
 
 from indxparse.BinaryParser import OverrunBufferException
 from indxparse.MFT import (
@@ -342,13 +343,14 @@ def print_indx_info(options):
         prefix=options.prefix,
         progress=options.progress,
     )
+    record: Optional[MFTRecord] = None
     try:
         record_num = int(options.infomode)
         record_buf = f.mft_get_record_buf(record_num)
         record = MFTRecord(record_buf, 0, False)
     except ValueError:
         record = f.mft_get_record_by_path(options.infomode)
-    if not record:
+    if record is None:
         print("Did not find directory entry for " + options.infomode)
         return
     print("Found directory entry for: " + options.infomode)

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -475,7 +475,7 @@ def print_indx_info(options):
     for b in record.attributes():
         print("  %s" % (Attribute.TYPES[b.type()]))
         print("    attribute name: %s" % (b.name() or "<none>"))
-        print("    attribute flags: " + ", ".join(get_flags(attr.flags())))
+        print("    attribute flags: " + ", ".join(get_flags(b.flags())))
         if b.non_resident() > 0:
             print("    resident: no")
             print("    data size: %d" % (b.data_size()))

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -419,32 +419,31 @@ def print_indx_info(options):
             attributes.append("has-view-index")
         return attributes
 
-    print(
-        "  attributes: "
-        + ", ".join(get_flags(record.standard_information().attributes()))
-    )
+    rsi = record.standard_information()
+    if rsi is None:
+        print("  SI not found")
+    else:
+        print("  attributes: " + ", ".join(get_flags(rsi.attributes())))
 
-    crtime = record.standard_information().created_time().isoformat("T") + "Z"
-    mtime = record.standard_information().modified_time().isoformat("T") + "Z"
-    chtime = record.standard_information().changed_time().isoformat("T") + "Z"
-    atime = record.standard_information().accessed_time().isoformat("T") + "Z"
+        crtime = rsi.created_time().isoformat("T") + "Z"
+        mtime = rsi.modified_time().isoformat("T") + "Z"
+        chtime = rsi.changed_time().isoformat("T") + "Z"
+        atime = rsi.accessed_time().isoformat("T") + "Z"
 
-    print("  SI modified: %s" % (mtime))
-    print("  SI accessed: %s" % (atime))
-    print("  SI changed: %s" % (chtime))
-    print("  SI birthed: %s" % (crtime))
+        print("  SI modified: %s" % (mtime))
+        print("  SI accessed: %s" % (atime))
+        print("  SI changed: %s" % (chtime))
+        print("  SI birthed: %s" % (crtime))
 
-    try:
-        # since the fields are sequential, we can handle an exception half way through here
-        #  and then ignore the remaining items. Dont have to worry about individual try/catches
-        print(
-            "  owner id (quota info): %d" % (record.standard_information().owner_id())
-        )
-        print("  security id: %d" % (record.standard_information().security_id()))
-        print("  quota charged: %d" % (record.standard_information().quota_charged()))
-        print("  USN: %d" % (record.standard_information().usn()))
-    except StandardInformationFieldDoesNotExist:
-        pass
+        try:
+            # since the fields are sequential, we can handle an exception half way through here
+            #  and then ignore the remaining items. Dont have to worry about individual try/catches
+            print("  owner id (quota info): %d" % (rsi.owner_id()))
+            print("  security id: %d" % (rsi.security_id()))
+            print("  quota charged: %d" % (rsi.quota_charged()))
+            print("  USN: %d" % (rsi.usn()))
+        except StandardInformationFieldDoesNotExist:
+            pass
 
     print("Filenames:")
     for b in record.attributes():

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -512,7 +512,7 @@ def print_indx_info(options):
     if indxroot.non_resident() != 0:
         # This shouldn't happen.
         print("INDX_ROOT attribute is non-resident")
-        for rle in indxroot.runlist().entries():
+        for rle in indxroot.runlist()._entries():
             print("Cluster %s, length %s" % (hex(rle.offset()), hex(rle.length())))
     else:
         print("INDX_ROOT attribute is resident")

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -30,7 +30,7 @@ import logging
 import re
 import sys
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional, Union
 
 from indxparse.BinaryParser import OverrunBufferException
 from indxparse.MFT import (
@@ -52,7 +52,14 @@ from indxparse.MFT import (
 verbose = False
 
 
-def information_bodyfile(path, size, inode, owner_id, info, attributes=None):
+def information_bodyfile(
+    path: str,
+    size: int,
+    inode: int,
+    owner_id: int,
+    info: Union[FilenameAttribute, StandardInformation],
+    attributes: Optional[List[str]] = None,
+) -> str:
     if not attributes:
         attributes = []
     try:
@@ -86,7 +93,9 @@ def information_bodyfile(path, size, inode, owner_id, info, attributes=None):
     )
 
 
-def record_bodyfile(ntfsfile, record, inode=None, attributes=None):
+def record_bodyfile(
+    ntfsfile: NTFSFile, record: MFTRecord, attributes: Optional[List[str]] = None
+) -> str:
     """
     Return a bodyfile formatted string for the given MFT record.
     The string contains metadata for the one file described by the record.
@@ -162,7 +171,11 @@ def record_bodyfile(ntfsfile, record, inode=None, attributes=None):
     return ret
 
 
-def node_header_bodyfile(options, node_header, basepath):
+def node_header_bodyfile(
+    options: argparse.Namespace,
+    node_header: NTATTR_STANDARD_INDEX_HEADER,
+    basepath: str,
+) -> str:
     """
     Returns a bodyfile formatted string for all INDX entries following the
     given INDX node header.
@@ -189,7 +202,11 @@ def node_header_bodyfile(options, node_header, basepath):
     return ret
 
 
-def record_indx_entries_bodyfile(options, ntfsfile, record):
+def record_indx_entries_bodyfile(
+    options: argparse.Namespace,
+    ntfsfile: NTFSFile,
+    record: MFTRecord,
+) -> str:
     """
     Returns a bodyfile formatted string for all INDX entries associated with
     the given MFT record
@@ -254,7 +271,11 @@ def try_write(s: str) -> None:
         )
 
 
-def print_nonresident_indx_bodyfile(options, buf, basepath=""):
+def print_nonresident_indx_bodyfile(
+    options: argparse.Namespace,
+    buf: array.array[Any],
+    basepath: str = "",
+) -> None:
     offset = 0
     try:
         irh = IndexRecordHeader(buf, offset, False)
@@ -274,7 +295,9 @@ def print_nonresident_indx_bodyfile(options, buf, basepath=""):
     return
 
 
-def print_bodyfile(options):
+def print_bodyfile(
+    options: argparse.Namespace,
+) -> None:
     if options.filetype == "mft" or options.filetype == "image":
         ntfs_file = NTFSFile(
             clustersize=options.clustersize,
@@ -334,7 +357,7 @@ def print_bodyfile(options):
         print_nonresident_indx_bodyfile(options, buf)
 
 
-def print_indx_info(options):
+def print_indx_info(options: argparse.Namespace) -> None:
     f = NTFSFile(
         clustersize=options.clustersize,
         filename=options.filename,
@@ -385,7 +408,7 @@ def print_indx_info(options):
             if rfni is not None:
                 print("  size: %d bytes" % (rfni.logical_size()))
 
-    def get_flags(flags) -> List[str]:
+    def get_flags(flags: int) -> List[str]:
         attributes = []
         if flags & 0x01:
             attributes.append("readonly")
@@ -598,7 +621,7 @@ def print_indx_info(options):
     return
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Parse NTFS " "filesystem structures.")
     parser.add_argument(
         "-t",

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -381,7 +381,9 @@ def print_indx_info(options):
         if data_attr and data_attr.non_resident() > 0:
             print("  size: %d bytes" % (data_attr.data_size()))
         else:
-            print("  size: %d bytes" % (record.filename_information().logical_size()))
+            rfni = record.filename_information()
+            if rfni is not None:
+                print("  size: %d bytes" % (rfni.logical_size()))
 
     def get_flags(flags):
         attributes = []

--- a/indxparse/MFTINDX.py
+++ b/indxparse/MFTINDX.py
@@ -23,12 +23,32 @@
 #
 #
 #   Version v.1.2.0
+import argparse
+import array
 import calendar
+import logging
+import re
+import sys
+from datetime import datetime
 
-from indxparse.MFT import *
+from indxparse.BinaryParser import OverrunBufferException
+from indxparse.MFT import (
+    ATTR_TYPE,
+    MREF,
+    MSEQNO,
+    NTATTR_STANDARD_INDEX_HEADER,
+    Attribute,
+    FilenameAttribute,
+    IndexRecordHeader,
+    IndexRootHeader,
+    InvalidAttributeException,
+    MFTRecord,
+    NTFSFile,
+    StandardInformation,
+    StandardInformationFieldDoesNotExist,
+)
 
 verbose = False
-import argparse
 
 
 def information_bodyfile(path, size, inode, owner_id, info, attributes=None):

--- a/indxparse/MFTView.py
+++ b/indxparse/MFTView.py
@@ -191,7 +191,7 @@ class AppModel(wx.EvtHandler):
             def __init__(self, count):
                 self.value = count
 
-        def add_node(mftfile, record):
+        def add_node(mftfile: NTFSFile, record: MFTRecord) -> None:
             """
             Add the given record to the internal list of nodes,
               adding the parent nodes as appropriate.


### PR DESCRIPTION
This patch series has three primary objectives:

1. Begin `mypy --strict` review of `${top_srcdir}/indxparse`, identifying an exemplar script.
2. Have `MFTINDX.py` pass `mypy --strict`.
3. Remove the `options` (`argparse.Namespace`) argument-passing style from `MFTINDX.py`.

Some bugs were fixed as type review was occurring.  For instance, some variables that were reused in longer functions, with different types at different points, instigated variable renames, and highlighted an old copy-paste error obscured by a variable name persisting after a loop.  Also, some code branches were updated to handle returned `None`s from functions not previously highlighted as returning some `Optional` value.

Each patch's log message describes its purpose.

Disclaimer: Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.