### PR TITLE
Update list of .py files currently passing mypy --strict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ check-mypy: \
 	source venv/bin/activate \
 	  && mypy \
 	    --strict \
-	    indxparse/MFTINDX.py
+	    indxparse/INDXFind.py \
+	    indxparse/MFTINDX.py \
+	    indxparse/__init__.py
 
 check-third_party:
 	$(MAKE) \


### PR DESCRIPTION
This is in partial satisfaction of adding mypy type checking, noted on #38 .

I made this list by adding everything under `/indxparse` and deleting lines until `make check` stopped failing.

Disclaimer:
Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.