### PR TITLE
Test list_mft.py JSON output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ all:
 check: \
   check-mypy \
   check-third_party
+	$(MAKE) \
+	  --directory tests \
+	  check
 
 check-mypy: \
   .venv.done.log
@@ -61,6 +64,9 @@ check-third_party:
 	  check
 
 clean:
+	@$(MAKE) \
+	  --directory tests \
+	  clean
 	@$(MAKE) \
 	  --directory third_party \
 	  clean

--- a/indxparse/list_mft.py
+++ b/indxparse/list_mft.py
@@ -380,9 +380,13 @@ def main():
                     return json.JSONEncoder.default(self, obj)
 
             print("[")
+            record_count = 0
             for record, record_path in enum.enumerate_paths():
+                if record_count > 0:
+                    print(",")
+                record_count += 1
                 m = make_model(record, record_path)
-                print((json.dumps(m, cls=MFTEncoder, indent=2) + ","))
+                print(json.dumps(m, cls=MFTEncoder, indent=2))
                 progress.set_current(record.inode)
             print("]")
         else:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,48 @@
+#!/usr/bin/make -f
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties.  Pursuant to Title 17 Seciton 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States.  NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+all: \
+  all-console_scripts
+
+.PHONY: \
+  all-console_scripts \
+  all-list_mft
+
+# TODO: This list of unimplemented tests lines up with setup.cfg.
+# * all-INDXParse
+# * all-MFTINDX
+# * all-MFTView
+# * all-SDS_get_index
+# * all-extract_mft_record_slack
+# * all-fuse-mft
+# * all-get_file_info
+# * all-tree_mft
+all-console_scripts: \
+  all-list_mft
+
+all-list_mft:
+	$(MAKE) \
+	  --directory list_mft
+
+check: \
+  all
+
+clean:
+	@$(MAKE) \
+	  --directory list_mft \
+	  clean

--- a/tests/list_mft/Makefile
+++ b/tests/list_mft/Makefile
@@ -1,0 +1,44 @@
+#!/usr/bin/make -f
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties.  Pursuant to Title 17 Seciton 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States.  NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../.. ; pwd)
+
+7_ntfs_undel_dd := $(top_srcdir)/third_party/7-undel-ntfs/7-ntfs-undel.dd
+
+all: \
+  out.json
+
+check: \
+  all
+
+clean:
+	@rm -f \
+	  *.json \
+	  _*
+
+out.json: \
+  $(7_ntfs_undel_dd) \
+  $(top_srcdir)/.venv.done.log \
+  $(top_srcdir)/indxparse/list_mft.py
+	rm -f _$@
+	source $(top_srcdir)/venv/bin/activate \
+	  && list_mft.py \
+	    --json \
+	    $< \
+	    > _$@
+	mv _$@ $@

--- a/tests/list_mft/Makefile
+++ b/tests/list_mft/Makefile
@@ -35,10 +35,14 @@ out.json: \
   $(7_ntfs_undel_dd) \
   $(top_srcdir)/.venv.done.log \
   $(top_srcdir)/indxparse/list_mft.py
-	rm -f _$@
+	rm -f __$@ _$@
 	source $(top_srcdir)/venv/bin/activate \
 	  && list_mft.py \
 	    --json \
 	    $< \
-	    > _$@
+	    > __$@
+	python3 -m json.tool \
+	  __$@ \
+	  _$@
+	rm __$@
 	mv _$@ $@

--- a/tests/list_mft/out.json
+++ b/tests/list_mft/out.json
@@ -1,6012 +1,5969 @@
 [
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$MFT",
-  "inode": 2005,
-  "is_active": true,
-  "is_directory": false,
-  "size": 39936,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$MFT",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 16384,
-    "physical_size": 16384,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
     {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$MFT",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 16384,
-      "physical_size": 16384,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 74,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 39936,
-      "allocated_size": 49152,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 2005,
-          "length": 16
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$MFT",
+        "inode": 2005,
+        "is_active": true,
+        "is_directory": false,
+        "size": 39936,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
         },
-        {
-          "offset": 4247,
-          "length": 32
-        }
-      ]
-    },
-    {
-      "type": "$BITMAP",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 8,
-      "allocated_size": 1024,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 2004,
-          "length": 1
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$MFT"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$MFT"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$MFTMirr",
-  "inode": 2006,
-  "is_active": true,
-  "is_directory": false,
-  "size": 4096,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$MFTMirr",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 4096,
-    "physical_size": 4096,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$MFTMirr",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 4096,
-      "physical_size": 4096,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 4096,
-      "allocated_size": 4096,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4069,
-          "length": 4
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$MFTMirr"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$MFTMirr"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$LogFile",
-  "inode": 2007,
-  "is_active": true,
-  "is_directory": false,
-  "size": 2097152,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$LogFile",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 2097152,
-    "physical_size": 2097152,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$LogFile",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 2097152,
-      "physical_size": 2097152,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 2097152,
-      "allocated_size": 2097152,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 2021,
-          "length": 2048
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$LogFile"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$LogFile"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$Volume",
-  "inode": 2008,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ]
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$Volume",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Volume",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 80,
-      "runs": []
-    },
-    {
-      "type": "$OBJECT ID/$VOLUME VERSION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 16,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$VOLUME NAME",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 16,
-      "runs": []
-    },
-    {
-      "type": "$VOLUME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 12,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 0,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$Volume"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$Volume@",
-    "NTFS_DELp"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$AttrDef",
-  "inode": 2009,
-  "is_active": true,
-  "is_directory": false,
-  "size": 2560,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ]
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$AttrDef",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 36000,
-    "physical_size": 36864,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$AttrDef",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 36000,
-      "physical_size": 36864,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 2560,
-      "allocated_size": 3072,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 5249,
-          "length": 3
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$AttrDef"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$AttrDef"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$AttrDef"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$AttrDef"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$AttrDef"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$AttrDef"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$AttrDef"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$AttrDef"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$AttrDef"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "",
-  "inode": 2010,
-  "is_active": true,
-  "is_directory": true,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T20:19:31.399673Z",
-    "changed": "2004-02-29T20:19:31.399673Z",
-    "accessed": "2004-02-29T20:19:31.399673Z",
-    "flags": [
-      "hidden",
-      "system",
-      "archive"
-    ]
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": ".",
-    "flags": [
-      "hidden",
-      "system",
-      "has-indx"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": ".",
-      "flags": [
-        "hidden",
-        "system",
-        "has-indx"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 68,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 4172,
-      "allocated_size": 5120,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4113,
-          "length": 5
-        }
-      ]
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$I30",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 56,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ALLOCATION",
-      "name": "$I30",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 4096,
-      "allocated_size": 4096,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4109,
-          "length": 4
-        }
-      ]
-    },
-    {
-      "type": "$BITMAP",
-      "name": "$I30",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 8,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "."
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "."
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "."
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "."
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "."
-    },
-    {
-      "timestamp": "2004-02-29T20:19:31.399673Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "."
-    },
-    {
-      "timestamp": "2004-02-29T20:19:31.399673Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "."
-    },
-    {
-      "timestamp": "2004-02-29T20:19:31.399673Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "."
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$I300",
-    "$I30",
-    "$I30"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": [
-    "$I30",
-    "$I30"
-  ]
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$Bitmap",
-  "inode": 2011,
-  "is_active": true,
-  "is_directory": false,
-  "size": 752,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$Bitmap",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 752,
-    "physical_size": 1024,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Bitmap",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 752,
-      "physical_size": 1024,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 80,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 752,
-      "allocated_size": 1024,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4118,
-          "length": 1
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$Bitmap"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$Bitmap"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$Bitmap"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$Bitmap"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$Bitmap"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$Bitmap"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$Bitmap"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$Bitmap"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$Bitmap"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$Boot",
-  "inode": 2012,
-  "is_active": true,
-  "is_directory": false,
-  "size": 8192,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ]
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$Boot",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 8192,
-    "physical_size": 8192,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Boot",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 8192,
-      "physical_size": 8192,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 76,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 8192,
-      "allocated_size": 8192,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 0,
-          "length": 8
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$Boot"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$Boot"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$Boot"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$Boot"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$Boot"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$Boot"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$Boot"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$Boot"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$Boot"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$BadClus",
-  "inode": 2013,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$BadClus",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$BadClus",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 0,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "$Bad",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 6160384,
-      "allocated_size": 6160384,
-      "value_size": 0,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$BadClus"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$BadClus"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$BadClus"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$BadClus"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$BadClus"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$BadClus"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$BadClus"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$BadClus"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$BadClus",
-    "$Bad"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": [
-    "$Bad"
-  ]
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$Secure",
-  "inode": 2014,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system",
-      "has-view-index"
-    ],
-    "owner_id": 0,
-    "security_id": 257,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$Secure",
-    "flags": [],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": null,
-    "accessed": null,
-    "changed": null,
-    "created": null,
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Secure",
-      "flags": [],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": null,
-      "accessed": null,
-      "changed": null,
-      "created": null,
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 80,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "$SDS",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 263140,
-      "allocated_size": 263168,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4992,
-          "length": 257
-        }
-      ]
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$SDH",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 56,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$SII",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 288,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ALLOCATION",
-      "name": "$SDH",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 4096,
-      "allocated_size": 4096,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4086,
-          "length": 4
-        }
-      ]
-    },
-    {
-      "type": "$BITMAP",
-      "name": "$SDH",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 8,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": null,
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$Secure"
-    },
-    {
-      "timestamp": null,
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$Secure"
-    },
-    {
-      "timestamp": null,
-      "type": "modified",
-      "source": "$FN",
-      "path": "$Secure"
-    },
-    {
-      "timestamp": null,
-      "type": "changed",
-      "source": "$FN",
-      "path": "$Secure"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$Secure"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$Secure"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$Secure"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$Secure"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$Secure",
-    "$SDS",
-    "$SDH",
-    "$SII",
-    "$SDH",
-    "$SDH"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$UpCase",
-  "inode": 2015,
-  "is_active": true,
-  "is_directory": false,
-  "size": 131072,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$UpCase",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 131072,
-    "physical_size": 131072,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$UpCase",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 131072,
-      "physical_size": 131072,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 80,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 131072,
-      "allocated_size": 131072,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4119,
-          "length": 128
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$UpCase"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$UpCase"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$UpCase"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$UpCase"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$UpCase"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$UpCase"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$UpCase"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$UpCase"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$UpCase"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$Extend",
-  "inode": 2016,
-  "is_active": true,
-  "is_directory": true,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 257,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$Extend",
-    "flags": [
-      "hidden",
-      "system",
-      "has-indx"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Extend",
-      "flags": [
-        "hidden",
-        "system",
-        "has-indx"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 80,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$I30",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 344,
-      "runs": []
-    }
-  ],
-  "indx_entries": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$ObjId",
-      "flags": [
-        "hidden",
-        "system",
-        "archive",
-        "has-view-index"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:58:04.062469Z",
-      "accessed": "2004-02-29T19:58:04.062469Z",
-      "changed": "2004-02-29T19:58:04.062469Z",
-      "created": "2004-02-29T19:58:04.062469Z",
-      "parent_ref": 11,
-      "parent_seq": 11,
-      "inode": 25,
-      "sequence_num": 1
-    },
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Quota",
-      "flags": [
-        "hidden",
-        "system",
-        "archive",
-        "has-view-index"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:58:04.062469Z",
-      "accessed": "2004-02-29T19:58:04.062469Z",
-      "changed": "2004-02-29T19:58:04.062469Z",
-      "created": "2004-02-29T19:58:04.062469Z",
-      "parent_ref": 11,
-      "parent_seq": 11,
-      "inode": 24,
-      "sequence_num": 1
-    },
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Reparse",
-      "flags": [
-        "hidden",
-        "system",
-        "archive",
-        "has-view-index"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:58:04.062469Z",
-      "accessed": "2004-02-29T19:58:04.062469Z",
-      "changed": "2004-02-29T19:58:04.062469Z",
-      "created": "2004-02-29T19:58:04.062469Z",
-      "parent_ref": 11,
-      "parent_seq": 11,
-      "inode": 26,
-      "sequence_num": 1
-    }
-  ],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$Extend"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$Extend"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$Extend"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$Extend"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$Extend"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$Extend"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$Extend"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$Extend"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "INDX",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "INDX",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "INDX",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "INDX",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "INDX",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "INDX",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "INDX",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "INDX",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "INDX",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "INDX",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "INDX",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "INDX",
-      "path": "$Reparse"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$Extend",
-    "$I300",
-    "$ObjId",
-    "$Quota",
-    "$Reparse"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": [
-    "$Reparse"
-  ]
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 2017,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ]
-  },
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 0,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 2018,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ]
-  },
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 0,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 2019,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ]
-  },
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 0,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 2020,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ]
-  },
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 0,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\mult1.dat",
-  "inode": 2167,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T20:01:37.360390Z",
-    "modified": "2004-02-29T20:01:37.360390Z",
-    "changed": "2004-02-29T20:01:37.360390Z",
-    "accessed": "2004-02-29T20:01:37.360390Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "mult1.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:01:37.360390Z",
-    "accessed": "2004-02-29T20:01:37.360390Z",
-    "changed": "2004-02-29T20:01:37.360390Z",
-    "created": "2004-02-29T20:01:37.360390Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "mult1.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:01:37.360390Z",
-      "accessed": "2004-02-29T20:01:37.360390Z",
-      "changed": "2004-02-29T20:01:37.360390Z",
-      "created": "2004-02-29T20:01:37.360390Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 84,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 0,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "mult1.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "mult1.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$MFT",
-  "inode": 4069,
-  "is_active": true,
-  "is_directory": false,
-  "size": 39936,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$MFT",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 16384,
-    "physical_size": 16384,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$MFT",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 16384,
-      "physical_size": 16384,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 74,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 39936,
-      "allocated_size": 49152,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 2005,
-          "length": 16
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$MFT",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 16384,
+            "physical_size": 16384,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
         },
-        {
-          "offset": 4247,
-          "length": 32
-        }
-      ]
-    },
-    {
-      "type": "$BITMAP",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 8,
-      "allocated_size": 1024,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 2004,
-          "length": 1
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$MFT"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$MFT"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$MFT"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$MFTMirr",
-  "inode": 4070,
-  "is_active": true,
-  "is_directory": false,
-  "size": 4096,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$MFTMirr",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 4096,
-    "physical_size": 4096,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$MFTMirr",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 4096,
-      "physical_size": 4096,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 4096,
-      "allocated_size": 4096,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4069,
-          "length": 4
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$MFTMirr"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$MFTMirr"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$MFTMirr"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$LogFile",
-  "inode": 4071,
-  "is_active": true,
-  "is_directory": false,
-  "size": 2097152,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 256,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$LogFile",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 2097152,
-    "physical_size": 2097152,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$LogFile",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 2097152,
-      "physical_size": 2097152,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 2097152,
-      "allocated_size": 2097152,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 2021,
-          "length": 2048
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$LogFile"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$LogFile"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$LogFile"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$Volume",
-  "inode": 4072,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:57:57.513052Z",
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "flags": [
-      "hidden",
-      "system"
-    ]
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$Volume",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:57:57.513052Z",
-    "accessed": "2004-02-29T19:57:57.513052Z",
-    "changed": "2004-02-29T19:57:57.513052Z",
-    "created": "2004-02-29T19:57:57.513052Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Volume",
-      "flags": [
-        "hidden",
-        "system"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:57:57.513052Z",
-      "accessed": "2004-02-29T19:57:57.513052Z",
-      "changed": "2004-02-29T19:57:57.513052Z",
-      "created": "2004-02-29T19:57:57.513052Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 80,
-      "runs": []
-    },
-    {
-      "type": "$OBJECT ID/$VOLUME VERSION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 16,
-      "runs": []
-    },
-    {
-      "type": "$SECURITY DESCRIPTOR",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$VOLUME NAME",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 16,
-      "runs": []
-    },
-    {
-      "type": "$VOLUME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 12,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 0,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$Volume"
-    },
-    {
-      "timestamp": "2004-02-29T19:57:57.513052Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$Volume"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$Volume@",
-    "NTFS_DELp"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 4247,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": null,
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 4248,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": null,
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 4249,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": null,
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 4250,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": null,
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 4251,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": null,
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 4252,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": null,
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 4253,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": null,
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "??",
-  "inode": 4254,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": null,
-  "filename_information": null,
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [],
-  "attributes": [],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$Quota",
-  "inode": 4255,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:58:04.062469Z",
-    "modified": "2004-02-29T19:58:04.062469Z",
-    "changed": "2004-02-29T19:58:04.062469Z",
-    "accessed": "2004-02-29T19:58:04.062469Z",
-    "flags": [
-      "hidden",
-      "system",
-      "archive",
-      "has-view-index"
-    ],
-    "owner_id": 0,
-    "security_id": 257,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$Quota",
-    "flags": [
-      "hidden",
-      "system",
-      "archive",
-      "has-view-index"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:58:04.062469Z",
-    "accessed": "2004-02-29T19:58:04.062469Z",
-    "changed": "2004-02-29T19:58:04.062469Z",
-    "created": "2004-02-29T19:58:04.062469Z",
-    "parent_ref": 11,
-    "parent_seq": 11
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Quota",
-      "flags": [
-        "hidden",
-        "system",
-        "archive",
-        "has-view-index"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:58:04.062469Z",
-      "accessed": "2004-02-29T19:58:04.062469Z",
-      "changed": "2004-02-29T19:58:04.062469Z",
-      "created": "2004-02-29T19:58:04.062469Z",
-      "parent_ref": 11,
-      "parent_seq": 11
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 78,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$O",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 88,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$Q",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 208,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$Quota"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$Quota"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$Quota"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$ObjId",
-  "inode": 4256,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:58:04.062469Z",
-    "modified": "2004-02-29T19:58:04.062469Z",
-    "changed": "2004-02-29T19:58:04.062469Z",
-    "accessed": "2004-02-29T19:58:04.062469Z",
-    "flags": [
-      "hidden",
-      "system",
-      "archive",
-      "has-view-index"
-    ],
-    "owner_id": 0,
-    "security_id": 257,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$ObjId",
-    "flags": [
-      "hidden",
-      "system",
-      "archive",
-      "has-view-index"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:58:04.062469Z",
-    "accessed": "2004-02-29T19:58:04.062469Z",
-    "changed": "2004-02-29T19:58:04.062469Z",
-    "created": "2004-02-29T19:58:04.062469Z",
-    "parent_ref": 11,
-    "parent_seq": 11
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$ObjId",
-      "flags": [
-        "hidden",
-        "system",
-        "archive",
-        "has-view-index"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:58:04.062469Z",
-      "accessed": "2004-02-29T19:58:04.062469Z",
-      "changed": "2004-02-29T19:58:04.062469Z",
-      "created": "2004-02-29T19:58:04.062469Z",
-      "parent_ref": 11,
-      "parent_seq": 11
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 78,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$O",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 136,
-      "runs": []
-    }
-  ],
-  "indx_entries": [
-    {
-      "type": "POSIX",
-      "name": "",
-      "flags": [],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "1603-09-05T08:14:53.013197Z",
-      "accessed": null,
-      "changed": null,
-      "created": "1970-01-01T00:00:00Z",
-      "parent_ref": 268755454544440,
-      "parent_seq": 17784,
-      "inode": 3670048,
-      "sequence_num": 0
-    }
-  ],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "1603-09-05T08:14:53.013197Z",
-      "type": "modified",
-      "source": "INDX",
-      "path": ""
-    },
-    {
-      "timestamp": "1970-01-01T00:00:00Z",
-      "type": "birthed",
-      "source": "INDX",
-      "path": ""
-    },
-    {
-      "timestamp": null,
-      "type": "accessed",
-      "source": "INDX",
-      "path": ""
-    },
-    {
-      "timestamp": null,
-      "type": "changed",
-      "source": "INDX",
-      "path": ""
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$ObjId"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$ObjId"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$ObjId"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\$Reparse",
-  "inode": 4257,
-  "is_active": true,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:58:04.062469Z",
-    "modified": "2004-02-29T19:58:04.062469Z",
-    "changed": "2004-02-29T19:58:04.062469Z",
-    "accessed": "2004-02-29T19:58:04.062469Z",
-    "flags": [
-      "hidden",
-      "system",
-      "archive",
-      "has-view-index"
-    ],
-    "owner_id": 0,
-    "security_id": 257,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "$Reparse",
-    "flags": [
-      "hidden",
-      "system",
-      "archive",
-      "has-view-index"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:58:04.062469Z",
-    "accessed": "2004-02-29T19:58:04.062469Z",
-    "changed": "2004-02-29T19:58:04.062469Z",
-    "created": "2004-02-29T19:58:04.062469Z",
-    "parent_ref": 11,
-    "parent_seq": 11
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "$Reparse",
-      "flags": [
-        "hidden",
-        "system",
-        "archive",
-        "has-view-index"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:58:04.062469Z",
-      "accessed": "2004-02-29T19:58:04.062469Z",
-      "changed": "2004-02-29T19:58:04.062469Z",
-      "created": "2004-02-29T19:58:04.062469Z",
-      "parent_ref": 11,
-      "parent_seq": 11
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$R",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "$Reparse"
-    },
-    {
-      "timestamp": "2004-02-29T19:58:04.062469Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "$Reparse"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "$Reparse"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\System Volume Information",
-  "inode": 4258,
-  "is_active": true,
-  "is_directory": true,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T19:59:10.189751Z",
-    "modified": "2004-02-29T19:59:11.191191Z",
-    "changed": "2004-02-29T19:59:11.191191Z",
-    "accessed": "2004-02-29T20:18:36.351355Z",
-    "flags": [
-      "hidden",
-      "system"
-    ],
-    "owner_id": 0,
-    "security_id": 258,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32",
-    "name": "System Volume Information",
-    "flags": [
-      "hidden",
-      "system",
-      "has-indx"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T19:59:10.189751Z",
-    "accessed": "2004-02-29T19:59:10.189751Z",
-    "changed": "2004-02-29T19:59:10.189751Z",
-    "created": "2004-02-29T19:59:10.189751Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "DOS 8.3",
-      "name": "SYSTEM~1",
-      "flags": [
-        "hidden",
-        "system",
-        "has-indx"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:59:10.189751Z",
-      "accessed": "2004-02-29T19:59:10.189751Z",
-      "changed": "2004-02-29T19:59:10.189751Z",
-      "created": "2004-02-29T19:59:10.189751Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    },
-    {
-      "type": "WIN32",
-      "name": "System Volume Information",
-      "flags": [
-        "hidden",
-        "system",
-        "has-indx"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T19:59:10.189751Z",
-      "accessed": "2004-02-29T19:59:10.189751Z",
-      "changed": "2004-02-29T19:59:10.189751Z",
-      "created": "2004-02-29T19:59:10.189751Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 116,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$I30",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 160,
-      "runs": []
-    }
-  ],
-  "indx_entries": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "tracking.log",
-      "flags": [
-        "hidden",
-        "system",
-        "archive"
-      ],
-      "logical_size": 20480,
-      "physical_size": 20480,
-      "modified": "2004-02-29T20:06:12.766405Z",
-      "accessed": "2004-02-29T20:06:12.766405Z",
-      "changed": "2004-02-29T20:06:12.766405Z",
-      "created": "2004-02-29T19:59:10.239822Z",
-      "parent_ref": 27,
-      "parent_seq": 1,
-      "inode": 28,
-      "sequence_num": 2
-    }
-  ],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "System Volume Information"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "SYSTEM~1"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "SYSTEM~1"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "SYSTEM~1"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "SYSTEM~1"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "System Volume Information"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "System Volume Information"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "System Volume Information"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.189751Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "System Volume Information"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.239822Z",
-      "type": "birthed",
-      "source": "INDX",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:11.191191Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "System Volume Information"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:11.191191Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "System Volume Information"
-    },
-    {
-      "timestamp": "2004-02-29T20:06:12.766405Z",
-      "type": "accessed",
-      "source": "INDX",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T20:06:12.766405Z",
-      "type": "modified",
-      "source": "INDX",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T20:06:12.766405Z",
-      "type": "changed",
-      "source": "INDX",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T20:18:36.351355Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "System Volume Information"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "SYSTEM~1olu0",
-    "System Volume Information",
-    "$I300",
-    "tracking.log"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": [
-    "TRACKI~1.TMP"
-  ]
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\tracking.log",
-  "inode": 4259,
-  "is_active": true,
-  "is_directory": false,
-  "size": 20480,
-  "standard_information": {
-    "created": "2004-02-29T19:59:10.239822Z",
-    "modified": "2004-02-29T20:06:12.766405Z",
-    "changed": "2004-02-29T20:06:12.766405Z",
-    "accessed": "2004-02-29T20:06:12.766405Z",
-    "flags": [
-      "hidden",
-      "system",
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 259,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "tracking.log",
-    "flags": [
-      "hidden",
-      "system",
-      "archive"
-    ],
-    "logical_size": 20480,
-    "physical_size": 20480,
-    "modified": "2004-02-29T19:59:11.191191Z",
-    "accessed": "2004-02-29T19:59:11.191191Z",
-    "changed": "2004-02-29T19:59:11.191191Z",
-    "created": "2004-02-29T19:59:10.239822Z",
-    "parent_ref": 27,
-    "parent_seq": 1
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "tracking.log",
-      "flags": [
-        "hidden",
-        "system",
-        "archive"
-      ],
-      "logical_size": 20480,
-      "physical_size": 20480,
-      "modified": "2004-02-29T19:59:11.191191Z",
-      "accessed": "2004-02-29T19:59:11.191191Z",
-      "changed": "2004-02-29T19:59:11.191191Z",
-      "created": "2004-02-29T19:59:10.239822Z",
-      "parent_ref": 27,
-      "parent_seq": 1
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 90,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 20480,
-      "allocated_size": 20480,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 5252,
-          "length": 20
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T19:59:10.239822Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:10.239822Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:11.191191Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:11.191191Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T19:59:11.191191Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T20:06:12.766405Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T20:06:12.766405Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "tracking.log"
-    },
-    {
-      "timestamp": "2004-02-29T20:06:12.766405Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "tracking.log"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "tracking.log.tm"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": [
-    "tracking.log.tmp"
-  ]
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\frag1.dat",
-  "inode": 4260,
-  "is_active": false,
-  "is_directory": false,
-  "size": 1584,
-  "standard_information": {
-    "created": "2004-02-29T20:00:17.215147Z",
-    "modified": "2004-02-29T20:00:40.698915Z",
-    "changed": "2004-02-29T20:00:40.698915Z",
-    "accessed": "2004-02-29T20:00:40.698915Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "frag1.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:00:17.215147Z",
-    "accessed": "2004-02-29T20:00:17.215147Z",
-    "changed": "2004-02-29T20:00:17.215147Z",
-    "created": "2004-02-29T20:00:17.215147Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "frag1.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:00:17.215147Z",
-      "accessed": "2004-02-29T20:00:17.215147Z",
-      "changed": "2004-02-29T20:00:17.215147Z",
-      "created": "2004-02-29T20:00:17.215147Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 84,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 1584,
-      "allocated_size": 2048,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4073,
-          "length": 1
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$MFT",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 16384,
+                "physical_size": 16384,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 74,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 39936,
+                "allocated_size": 49152,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 2005,
+                        "length": 16
+                    },
+                    {
+                        "offset": 4247,
+                        "length": 32
+                    }
+                ]
+            },
+            {
+                "type": "$BITMAP",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 8,
+                "allocated_size": 1024,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 2004,
+                        "length": 1
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$MFT"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$MFT"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$MFTMirr",
+        "inode": 2006,
+        "is_active": true,
+        "is_directory": false,
+        "size": 4096,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
         },
-        {
-          "offset": 4075,
-          "length": 1
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:00:17.215147Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "frag1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:17.215147Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "frag1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:17.215147Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "frag1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:17.215147Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "frag1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:17.215147Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "frag1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:40.698915Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "frag1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:40.698915Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "frag1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:40.698915Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "frag1.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "frag1.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\frag2.dat",
-  "inode": 4261,
-  "is_active": false,
-  "is_directory": false,
-  "size": 3873,
-  "standard_information": {
-    "created": "2004-02-29T20:00:29.452744Z",
-    "modified": "2004-02-29T20:02:54.891874Z",
-    "changed": "2004-02-29T20:02:54.891874Z",
-    "accessed": "2004-02-29T20:02:54.891874Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "frag2.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:00:29.452744Z",
-    "accessed": "2004-02-29T20:00:29.452744Z",
-    "changed": "2004-02-29T20:00:29.452744Z",
-    "created": "2004-02-29T20:00:29.452744Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "frag2.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:00:29.452744Z",
-      "accessed": "2004-02-29T20:00:29.452744Z",
-      "changed": "2004-02-29T20:00:29.452744Z",
-      "created": "2004-02-29T20:00:29.452744Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 84,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 3873,
-      "allocated_size": 4096,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4074,
-          "length": 1
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$MFTMirr",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 4096,
+            "physical_size": 4096,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
         },
-        {
-          "offset": 4076,
-          "length": 2
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$MFTMirr",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 4096,
+                "physical_size": 4096,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 4096,
+                "allocated_size": 4096,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4069,
+                        "length": 4
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$MFTMirr"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$MFTMirr"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$LogFile",
+        "inode": 2007,
+        "is_active": true,
+        "is_directory": false,
+        "size": 2097152,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
         },
-        {
-          "offset": 4085,
-          "length": 1
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:00:29.452744Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "frag2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:29.452744Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "frag2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:29.452744Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "frag2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:29.452744Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "frag2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:00:29.452744Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "frag2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:02:54.891874Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "frag2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:02:54.891874Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "frag2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:02:54.891874Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "frag2.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "frag2.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\sing1.dat",
-  "inode": 4262,
-  "is_active": false,
-  "is_directory": false,
-  "size": 780,
-  "standard_information": {
-    "created": "2004-02-29T20:01:24.301613Z",
-    "modified": "2004-02-29T20:01:24.321642Z",
-    "changed": "2004-02-29T20:01:24.321642Z",
-    "accessed": "2004-02-29T20:01:24.321642Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "sing1.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:01:24.301613Z",
-    "accessed": "2004-02-29T20:01:24.301613Z",
-    "changed": "2004-02-29T20:01:24.301613Z",
-    "created": "2004-02-29T20:01:24.301613Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "sing1.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:01:24.301613Z",
-      "accessed": "2004-02-29T20:01:24.301613Z",
-      "changed": "2004-02-29T20:01:24.301613Z",
-      "created": "2004-02-29T20:01:24.301613Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 84,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 780,
-      "allocated_size": 1024,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4078,
-          "length": 1
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:01:24.301613Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "sing1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:24.301613Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "sing1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:24.301613Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "sing1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:24.301613Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "sing1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:24.301613Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "sing1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:24.321642Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "sing1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:24.321642Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "sing1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:24.321642Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "sing1.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "sing1.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\mult1.dat",
-  "inode": 4263,
-  "is_active": false,
-  "is_directory": false,
-  "size": 3801,
-  "standard_information": {
-    "created": "2004-02-29T20:01:37.360390Z",
-    "modified": "2004-02-29T20:02:22.054657Z",
-    "changed": "2004-02-29T20:02:22.054657Z",
-    "accessed": "2004-02-29T20:02:22.054657Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "mult1.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:01:37.360390Z",
-    "accessed": "2004-02-29T20:01:37.360390Z",
-    "changed": "2004-02-29T20:01:37.360390Z",
-    "created": "2004-02-29T20:01:37.360390Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "mult1.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:01:37.360390Z",
-      "accessed": "2004-02-29T20:01:37.360390Z",
-      "changed": "2004-02-29T20:01:37.360390Z",
-      "created": "2004-02-29T20:01:37.360390Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 84,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 3801,
-      "allocated_size": 4096,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4079,
-          "length": 4
-        }
-      ]
-    },
-    {
-      "type": "$DATA",
-      "name": "ADS",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 1234,
-      "allocated_size": 2048,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4083,
-          "length": 2
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:01:37.360390Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:02:22.054657Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:02:22.054657Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "mult1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:02:22.054657Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "mult1.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "mult1.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\dir1",
-  "inode": 4264,
-  "is_active": false,
-  "is_directory": true,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T20:03:00.610098Z",
-    "modified": "2004-02-29T20:03:00.610098Z",
-    "changed": "2004-02-29T20:03:00.610098Z",
-    "accessed": "2004-02-29T20:03:00.610098Z",
-    "flags": [
-      "has-indx"
-    ],
-    "owner_id": 0,
-    "security_id": 261,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "dir1",
-    "flags": [
-      "has-indx"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:03:00.610098Z",
-    "accessed": "2004-02-29T20:03:00.610098Z",
-    "changed": "2004-02-29T20:03:00.610098Z",
-    "created": "2004-02-29T20:03:00.610098Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "dir1",
-      "flags": [
-        "has-indx"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:03:00.610098Z",
-      "accessed": "2004-02-29T20:03:00.610098Z",
-      "changed": "2004-02-29T20:03:00.610098Z",
-      "created": "2004-02-29T20:03:00.610098Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 74,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$I30",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:03:00.610098Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "dir1"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:00.610098Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "dir1"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:00.610098Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "dir1"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:00.610098Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "dir1"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:00.610098Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "dir1"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:00.610098Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "dir1"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:00.610098Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "dir1"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:00.610098Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "dir1"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "dir1",
-    "$I300"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": [
-    "dir2",
-    "mult2.dat"
-  ]
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\dir2",
-  "inode": 4265,
-  "is_active": false,
-  "is_directory": true,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T20:03:03.684517Z",
-    "modified": "2004-02-29T20:03:03.684517Z",
-    "changed": "2004-02-29T20:03:03.684517Z",
-    "accessed": "2004-02-29T20:03:03.684517Z",
-    "flags": [
-      "has-indx"
-    ],
-    "owner_id": 0,
-    "security_id": 261,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "dir2",
-    "flags": [
-      "has-indx"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:03:03.684517Z",
-    "accessed": "2004-02-29T20:03:03.684517Z",
-    "changed": "2004-02-29T20:03:03.684517Z",
-    "created": "2004-02-29T20:03:03.684517Z",
-    "parent_ref": 33,
-    "parent_seq": 1
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "dir2",
-      "flags": [
-        "has-indx"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:03:03.684517Z",
-      "accessed": "2004-02-29T20:03:03.684517Z",
-      "changed": "2004-02-29T20:03:03.684517Z",
-      "created": "2004-02-29T20:03:03.684517Z",
-      "parent_ref": 33,
-      "parent_seq": 1
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 74,
-      "runs": []
-    },
-    {
-      "type": "$INDEX ROOT",
-      "name": "$I30",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 48,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:03:03.684517Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "dir2"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:03.684517Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "dir2"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:03.684517Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "dir2"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:03.684517Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "dir2"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:03.684517Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "dir2"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:03.684517Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "dir2"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:03.684517Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "dir2"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:03.684517Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "dir2"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "dir2",
-    "$I300"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": [
-    "frag3.dat"
-  ]
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\frag3.dat",
-  "inode": 4266,
-  "is_active": false,
-  "is_directory": false,
-  "size": 2027,
-  "standard_information": {
-    "created": "2004-02-29T20:03:24.083851Z",
-    "modified": "2004-02-29T20:03:49.340168Z",
-    "changed": "2004-02-29T20:03:49.340168Z",
-    "accessed": "2004-02-29T20:03:49.340168Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "frag3.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:03:24.083851Z",
-    "accessed": "2004-02-29T20:03:24.083851Z",
-    "changed": "2004-02-29T20:03:24.083851Z",
-    "created": "2004-02-29T20:03:24.083851Z",
-    "parent_ref": 34,
-    "parent_seq": 1
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "frag3.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:03:24.083851Z",
-      "accessed": "2004-02-29T20:03:24.083851Z",
-      "changed": "2004-02-29T20:03:24.083851Z",
-      "created": "2004-02-29T20:03:24.083851Z",
-      "parent_ref": 34,
-      "parent_seq": 1
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 84,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 2027,
-      "allocated_size": 2048,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4090,
-          "length": 1
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$LogFile",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 2097152,
+            "physical_size": 2097152,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
         },
-        {
-          "offset": 4093,
-          "length": 1
-        }
-      ]
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$LogFile",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 2097152,
+                "physical_size": 2097152,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 2097152,
+                "allocated_size": 2097152,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 2021,
+                        "length": 2048
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$LogFile"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$LogFile"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$Volume",
+        "inode": 2008,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ]
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$Volume",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Volume",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 80,
+                "runs": []
+            },
+            {
+                "type": "$OBJECT ID/$VOLUME VERSION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 16,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$VOLUME NAME",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 16,
+                "runs": []
+            },
+            {
+                "type": "$VOLUME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 12,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 0,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$Volume"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$Volume@",
+            "NTFS_DELp"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$AttrDef",
+        "inode": 2009,
+        "is_active": true,
+        "is_directory": false,
+        "size": 2560,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ]
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$AttrDef",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 36000,
+            "physical_size": 36864,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$AttrDef",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 36000,
+                "physical_size": 36864,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 2560,
+                "allocated_size": 3072,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 5249,
+                        "length": 3
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$AttrDef"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$AttrDef"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$AttrDef"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$AttrDef"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$AttrDef"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$AttrDef"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$AttrDef"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$AttrDef"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$AttrDef"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "",
+        "inode": 2010,
+        "is_active": true,
+        "is_directory": true,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T20:19:31.399673Z",
+            "changed": "2004-02-29T20:19:31.399673Z",
+            "accessed": "2004-02-29T20:19:31.399673Z",
+            "flags": [
+                "hidden",
+                "system",
+                "archive"
+            ]
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": ".",
+            "flags": [
+                "hidden",
+                "system",
+                "has-indx"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": ".",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "has-indx"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 68,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 4172,
+                "allocated_size": 5120,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4113,
+                        "length": 5
+                    }
+                ]
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$I30",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 56,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ALLOCATION",
+                "name": "$I30",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 4096,
+                "allocated_size": 4096,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4109,
+                        "length": 4
+                    }
+                ]
+            },
+            {
+                "type": "$BITMAP",
+                "name": "$I30",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 8,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "."
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "."
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "."
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "."
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "."
+            },
+            {
+                "timestamp": "2004-02-29T20:19:31.399673Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "."
+            },
+            {
+                "timestamp": "2004-02-29T20:19:31.399673Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "."
+            },
+            {
+                "timestamp": "2004-02-29T20:19:31.399673Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "."
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$I300",
+            "$I30",
+            "$I30"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": [
+            "$I30",
+            "$I30"
+        ]
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$Bitmap",
+        "inode": 2011,
+        "is_active": true,
+        "is_directory": false,
+        "size": 752,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$Bitmap",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 752,
+            "physical_size": 1024,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Bitmap",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 752,
+                "physical_size": 1024,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 80,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 752,
+                "allocated_size": 1024,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4118,
+                        "length": 1
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$Bitmap"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$Bitmap"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$Bitmap"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$Bitmap"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$Bitmap"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$Bitmap"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$Bitmap"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$Bitmap"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$Bitmap"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$Boot",
+        "inode": 2012,
+        "is_active": true,
+        "is_directory": false,
+        "size": 8192,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ]
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$Boot",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 8192,
+            "physical_size": 8192,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Boot",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 8192,
+                "physical_size": 8192,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 76,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 8192,
+                "allocated_size": 8192,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 0,
+                        "length": 8
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$Boot"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$Boot"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$Boot"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$Boot"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$Boot"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$Boot"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$Boot"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$Boot"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$Boot"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$BadClus",
+        "inode": 2013,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$BadClus",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$BadClus",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 0,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "$Bad",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 6160384,
+                "allocated_size": 6160384,
+                "value_size": 0,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$BadClus"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$BadClus"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$BadClus"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$BadClus"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$BadClus"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$BadClus"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$BadClus"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$BadClus"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$BadClus",
+            "$Bad"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": [
+            "$Bad"
+        ]
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$Secure",
+        "inode": 2014,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system",
+                "has-view-index"
+            ],
+            "owner_id": 0,
+            "security_id": 257,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$Secure",
+            "flags": [],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": null,
+            "accessed": null,
+            "changed": null,
+            "created": null,
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Secure",
+                "flags": [],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": null,
+                "accessed": null,
+                "changed": null,
+                "created": null,
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 80,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "$SDS",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 263140,
+                "allocated_size": 263168,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4992,
+                        "length": 257
+                    }
+                ]
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$SDH",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 56,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$SII",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 288,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ALLOCATION",
+                "name": "$SDH",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 4096,
+                "allocated_size": 4096,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4086,
+                        "length": 4
+                    }
+                ]
+            },
+            {
+                "type": "$BITMAP",
+                "name": "$SDH",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 8,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": null,
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$Secure"
+            },
+            {
+                "timestamp": null,
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$Secure"
+            },
+            {
+                "timestamp": null,
+                "type": "modified",
+                "source": "$FN",
+                "path": "$Secure"
+            },
+            {
+                "timestamp": null,
+                "type": "changed",
+                "source": "$FN",
+                "path": "$Secure"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$Secure"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$Secure"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$Secure"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$Secure"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$Secure",
+            "$SDS",
+            "$SDH",
+            "$SII",
+            "$SDH",
+            "$SDH"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$UpCase",
+        "inode": 2015,
+        "is_active": true,
+        "is_directory": false,
+        "size": 131072,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$UpCase",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 131072,
+            "physical_size": 131072,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$UpCase",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 131072,
+                "physical_size": 131072,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 80,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 131072,
+                "allocated_size": 131072,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4119,
+                        "length": 128
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$UpCase"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$UpCase"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$UpCase"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$UpCase"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$UpCase"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$UpCase"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$UpCase"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$UpCase"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$UpCase"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$Extend",
+        "inode": 2016,
+        "is_active": true,
+        "is_directory": true,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 257,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$Extend",
+            "flags": [
+                "hidden",
+                "system",
+                "has-indx"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Extend",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "has-indx"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 80,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$I30",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 344,
+                "runs": []
+            }
+        ],
+        "indx_entries": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$ObjId",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "archive",
+                    "has-view-index"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:58:04.062469Z",
+                "accessed": "2004-02-29T19:58:04.062469Z",
+                "changed": "2004-02-29T19:58:04.062469Z",
+                "created": "2004-02-29T19:58:04.062469Z",
+                "parent_ref": 11,
+                "parent_seq": 11,
+                "inode": 25,
+                "sequence_num": 1
+            },
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Quota",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "archive",
+                    "has-view-index"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:58:04.062469Z",
+                "accessed": "2004-02-29T19:58:04.062469Z",
+                "changed": "2004-02-29T19:58:04.062469Z",
+                "created": "2004-02-29T19:58:04.062469Z",
+                "parent_ref": 11,
+                "parent_seq": 11,
+                "inode": 24,
+                "sequence_num": 1
+            },
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Reparse",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "archive",
+                    "has-view-index"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:58:04.062469Z",
+                "accessed": "2004-02-29T19:58:04.062469Z",
+                "changed": "2004-02-29T19:58:04.062469Z",
+                "created": "2004-02-29T19:58:04.062469Z",
+                "parent_ref": 11,
+                "parent_seq": 11,
+                "inode": 26,
+                "sequence_num": 1
+            }
+        ],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$Extend"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$Extend"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$Extend"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$Extend"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$Extend"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$Extend"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$Extend"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$Extend"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "INDX",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "INDX",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "INDX",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "INDX",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "INDX",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "INDX",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "INDX",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "INDX",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "INDX",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "INDX",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "INDX",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "INDX",
+                "path": "$Reparse"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$Extend",
+            "$I300",
+            "$ObjId",
+            "$Quota",
+            "$Reparse"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": [
+            "$Reparse"
+        ]
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 2017,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ]
+        },
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 0,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 2018,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ]
+        },
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 0,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 2019,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ]
+        },
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 0,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 2020,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ]
+        },
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 0,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\mult1.dat",
+        "inode": 2167,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T20:01:37.360390Z",
+            "modified": "2004-02-29T20:01:37.360390Z",
+            "changed": "2004-02-29T20:01:37.360390Z",
+            "accessed": "2004-02-29T20:01:37.360390Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "mult1.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:01:37.360390Z",
+            "accessed": "2004-02-29T20:01:37.360390Z",
+            "changed": "2004-02-29T20:01:37.360390Z",
+            "created": "2004-02-29T20:01:37.360390Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "mult1.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:01:37.360390Z",
+                "accessed": "2004-02-29T20:01:37.360390Z",
+                "changed": "2004-02-29T20:01:37.360390Z",
+                "created": "2004-02-29T20:01:37.360390Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 84,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 0,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "mult1.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "mult1.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$MFT",
+        "inode": 4069,
+        "is_active": true,
+        "is_directory": false,
+        "size": 39936,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$MFT",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 16384,
+            "physical_size": 16384,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$MFT",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 16384,
+                "physical_size": 16384,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 74,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 39936,
+                "allocated_size": 49152,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 2005,
+                        "length": 16
+                    },
+                    {
+                        "offset": 4247,
+                        "length": 32
+                    }
+                ]
+            },
+            {
+                "type": "$BITMAP",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 8,
+                "allocated_size": 1024,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 2004,
+                        "length": 1
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$MFT"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$MFT"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$MFT"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$MFTMirr",
+        "inode": 4070,
+        "is_active": true,
+        "is_directory": false,
+        "size": 4096,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$MFTMirr",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 4096,
+            "physical_size": 4096,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$MFTMirr",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 4096,
+                "physical_size": 4096,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 4096,
+                "allocated_size": 4096,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4069,
+                        "length": 4
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$MFTMirr"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$MFTMirr"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$MFTMirr"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$LogFile",
+        "inode": 4071,
+        "is_active": true,
+        "is_directory": false,
+        "size": 2097152,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 256,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$LogFile",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 2097152,
+            "physical_size": 2097152,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$LogFile",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 2097152,
+                "physical_size": 2097152,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 2097152,
+                "allocated_size": 2097152,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 2021,
+                        "length": 2048
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$LogFile"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$LogFile"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$LogFile"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$Volume",
+        "inode": 4072,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:57:57.513052Z",
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "flags": [
+                "hidden",
+                "system"
+            ]
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$Volume",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:57:57.513052Z",
+            "accessed": "2004-02-29T19:57:57.513052Z",
+            "changed": "2004-02-29T19:57:57.513052Z",
+            "created": "2004-02-29T19:57:57.513052Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Volume",
+                "flags": [
+                    "hidden",
+                    "system"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:57:57.513052Z",
+                "accessed": "2004-02-29T19:57:57.513052Z",
+                "changed": "2004-02-29T19:57:57.513052Z",
+                "created": "2004-02-29T19:57:57.513052Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 80,
+                "runs": []
+            },
+            {
+                "type": "$OBJECT ID/$VOLUME VERSION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 16,
+                "runs": []
+            },
+            {
+                "type": "$SECURITY DESCRIPTOR",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$VOLUME NAME",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 16,
+                "runs": []
+            },
+            {
+                "type": "$VOLUME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 12,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 0,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$Volume"
+            },
+            {
+                "timestamp": "2004-02-29T19:57:57.513052Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$Volume"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$Volume@",
+            "NTFS_DELp"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 4247,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": null,
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 4248,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": null,
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 4249,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": null,
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 4250,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": null,
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 4251,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": null,
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 4252,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": null,
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 4253,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": null,
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "??",
+        "inode": 4254,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": null,
+        "filename_information": null,
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [],
+        "attributes": [],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$Quota",
+        "inode": 4255,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:58:04.062469Z",
+            "modified": "2004-02-29T19:58:04.062469Z",
+            "changed": "2004-02-29T19:58:04.062469Z",
+            "accessed": "2004-02-29T19:58:04.062469Z",
+            "flags": [
+                "hidden",
+                "system",
+                "archive",
+                "has-view-index"
+            ],
+            "owner_id": 0,
+            "security_id": 257,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$Quota",
+            "flags": [
+                "hidden",
+                "system",
+                "archive",
+                "has-view-index"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:58:04.062469Z",
+            "accessed": "2004-02-29T19:58:04.062469Z",
+            "changed": "2004-02-29T19:58:04.062469Z",
+            "created": "2004-02-29T19:58:04.062469Z",
+            "parent_ref": 11,
+            "parent_seq": 11
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Quota",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "archive",
+                    "has-view-index"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:58:04.062469Z",
+                "accessed": "2004-02-29T19:58:04.062469Z",
+                "changed": "2004-02-29T19:58:04.062469Z",
+                "created": "2004-02-29T19:58:04.062469Z",
+                "parent_ref": 11,
+                "parent_seq": 11
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 78,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$O",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 88,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$Q",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 208,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$Quota"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$Quota"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$Quota"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$ObjId",
+        "inode": 4256,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:58:04.062469Z",
+            "modified": "2004-02-29T19:58:04.062469Z",
+            "changed": "2004-02-29T19:58:04.062469Z",
+            "accessed": "2004-02-29T19:58:04.062469Z",
+            "flags": [
+                "hidden",
+                "system",
+                "archive",
+                "has-view-index"
+            ],
+            "owner_id": 0,
+            "security_id": 257,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$ObjId",
+            "flags": [
+                "hidden",
+                "system",
+                "archive",
+                "has-view-index"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:58:04.062469Z",
+            "accessed": "2004-02-29T19:58:04.062469Z",
+            "changed": "2004-02-29T19:58:04.062469Z",
+            "created": "2004-02-29T19:58:04.062469Z",
+            "parent_ref": 11,
+            "parent_seq": 11
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$ObjId",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "archive",
+                    "has-view-index"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:58:04.062469Z",
+                "accessed": "2004-02-29T19:58:04.062469Z",
+                "changed": "2004-02-29T19:58:04.062469Z",
+                "created": "2004-02-29T19:58:04.062469Z",
+                "parent_ref": 11,
+                "parent_seq": 11
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 78,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$O",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 136,
+                "runs": []
+            }
+        ],
+        "indx_entries": [
+            {
+                "type": "POSIX",
+                "name": "",
+                "flags": [],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "1603-09-05T08:14:53.013197Z",
+                "accessed": null,
+                "changed": null,
+                "created": "1970-01-01T00:00:00Z",
+                "parent_ref": 268755454544440,
+                "parent_seq": 17784,
+                "inode": 3670048,
+                "sequence_num": 0
+            }
+        ],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "1603-09-05T08:14:53.013197Z",
+                "type": "modified",
+                "source": "INDX",
+                "path": ""
+            },
+            {
+                "timestamp": "1970-01-01T00:00:00Z",
+                "type": "birthed",
+                "source": "INDX",
+                "path": ""
+            },
+            {
+                "timestamp": null,
+                "type": "accessed",
+                "source": "INDX",
+                "path": ""
+            },
+            {
+                "timestamp": null,
+                "type": "changed",
+                "source": "INDX",
+                "path": ""
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$ObjId"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$ObjId"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$ObjId"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\$Reparse",
+        "inode": 4257,
+        "is_active": true,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:58:04.062469Z",
+            "modified": "2004-02-29T19:58:04.062469Z",
+            "changed": "2004-02-29T19:58:04.062469Z",
+            "accessed": "2004-02-29T19:58:04.062469Z",
+            "flags": [
+                "hidden",
+                "system",
+                "archive",
+                "has-view-index"
+            ],
+            "owner_id": 0,
+            "security_id": 257,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "$Reparse",
+            "flags": [
+                "hidden",
+                "system",
+                "archive",
+                "has-view-index"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:58:04.062469Z",
+            "accessed": "2004-02-29T19:58:04.062469Z",
+            "changed": "2004-02-29T19:58:04.062469Z",
+            "created": "2004-02-29T19:58:04.062469Z",
+            "parent_ref": 11,
+            "parent_seq": 11
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "$Reparse",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "archive",
+                    "has-view-index"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:58:04.062469Z",
+                "accessed": "2004-02-29T19:58:04.062469Z",
+                "changed": "2004-02-29T19:58:04.062469Z",
+                "created": "2004-02-29T19:58:04.062469Z",
+                "parent_ref": 11,
+                "parent_seq": 11
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$R",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "$Reparse"
+            },
+            {
+                "timestamp": "2004-02-29T19:58:04.062469Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "$Reparse"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "$Reparse"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\System Volume Information",
+        "inode": 4258,
+        "is_active": true,
+        "is_directory": true,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T19:59:10.189751Z",
+            "modified": "2004-02-29T19:59:11.191191Z",
+            "changed": "2004-02-29T19:59:11.191191Z",
+            "accessed": "2004-02-29T20:18:36.351355Z",
+            "flags": [
+                "hidden",
+                "system"
+            ],
+            "owner_id": 0,
+            "security_id": 258,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32",
+            "name": "System Volume Information",
+            "flags": [
+                "hidden",
+                "system",
+                "has-indx"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T19:59:10.189751Z",
+            "accessed": "2004-02-29T19:59:10.189751Z",
+            "changed": "2004-02-29T19:59:10.189751Z",
+            "created": "2004-02-29T19:59:10.189751Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "DOS 8.3",
+                "name": "SYSTEM~1",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "has-indx"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:59:10.189751Z",
+                "accessed": "2004-02-29T19:59:10.189751Z",
+                "changed": "2004-02-29T19:59:10.189751Z",
+                "created": "2004-02-29T19:59:10.189751Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            },
+            {
+                "type": "WIN32",
+                "name": "System Volume Information",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "has-indx"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T19:59:10.189751Z",
+                "accessed": "2004-02-29T19:59:10.189751Z",
+                "changed": "2004-02-29T19:59:10.189751Z",
+                "created": "2004-02-29T19:59:10.189751Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 116,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$I30",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 160,
+                "runs": []
+            }
+        ],
+        "indx_entries": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "tracking.log",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "archive"
+                ],
+                "logical_size": 20480,
+                "physical_size": 20480,
+                "modified": "2004-02-29T20:06:12.766405Z",
+                "accessed": "2004-02-29T20:06:12.766405Z",
+                "changed": "2004-02-29T20:06:12.766405Z",
+                "created": "2004-02-29T19:59:10.239822Z",
+                "parent_ref": 27,
+                "parent_seq": 1,
+                "inode": 28,
+                "sequence_num": 2
+            }
+        ],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "System Volume Information"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "SYSTEM~1"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "SYSTEM~1"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "SYSTEM~1"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "SYSTEM~1"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "System Volume Information"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "System Volume Information"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "System Volume Information"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.189751Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "System Volume Information"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.239822Z",
+                "type": "birthed",
+                "source": "INDX",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:11.191191Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "System Volume Information"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:11.191191Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "System Volume Information"
+            },
+            {
+                "timestamp": "2004-02-29T20:06:12.766405Z",
+                "type": "accessed",
+                "source": "INDX",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T20:06:12.766405Z",
+                "type": "modified",
+                "source": "INDX",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T20:06:12.766405Z",
+                "type": "changed",
+                "source": "INDX",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T20:18:36.351355Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "System Volume Information"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "SYSTEM~1olu0",
+            "System Volume Information",
+            "$I300",
+            "tracking.log"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": [
+            "TRACKI~1.TMP"
+        ]
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\tracking.log",
+        "inode": 4259,
+        "is_active": true,
+        "is_directory": false,
+        "size": 20480,
+        "standard_information": {
+            "created": "2004-02-29T19:59:10.239822Z",
+            "modified": "2004-02-29T20:06:12.766405Z",
+            "changed": "2004-02-29T20:06:12.766405Z",
+            "accessed": "2004-02-29T20:06:12.766405Z",
+            "flags": [
+                "hidden",
+                "system",
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 259,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "tracking.log",
+            "flags": [
+                "hidden",
+                "system",
+                "archive"
+            ],
+            "logical_size": 20480,
+            "physical_size": 20480,
+            "modified": "2004-02-29T19:59:11.191191Z",
+            "accessed": "2004-02-29T19:59:11.191191Z",
+            "changed": "2004-02-29T19:59:11.191191Z",
+            "created": "2004-02-29T19:59:10.239822Z",
+            "parent_ref": 27,
+            "parent_seq": 1
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "tracking.log",
+                "flags": [
+                    "hidden",
+                    "system",
+                    "archive"
+                ],
+                "logical_size": 20480,
+                "physical_size": 20480,
+                "modified": "2004-02-29T19:59:11.191191Z",
+                "accessed": "2004-02-29T19:59:11.191191Z",
+                "changed": "2004-02-29T19:59:11.191191Z",
+                "created": "2004-02-29T19:59:10.239822Z",
+                "parent_ref": 27,
+                "parent_seq": 1
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 90,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 20480,
+                "allocated_size": 20480,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 5252,
+                        "length": 20
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T19:59:10.239822Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:10.239822Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:11.191191Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:11.191191Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T19:59:11.191191Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T20:06:12.766405Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T20:06:12.766405Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "tracking.log"
+            },
+            {
+                "timestamp": "2004-02-29T20:06:12.766405Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "tracking.log"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "tracking.log.tm"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": [
+            "tracking.log.tmp"
+        ]
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\frag1.dat",
+        "inode": 4260,
+        "is_active": false,
+        "is_directory": false,
+        "size": 1584,
+        "standard_information": {
+            "created": "2004-02-29T20:00:17.215147Z",
+            "modified": "2004-02-29T20:00:40.698915Z",
+            "changed": "2004-02-29T20:00:40.698915Z",
+            "accessed": "2004-02-29T20:00:40.698915Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "frag1.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:00:17.215147Z",
+            "accessed": "2004-02-29T20:00:17.215147Z",
+            "changed": "2004-02-29T20:00:17.215147Z",
+            "created": "2004-02-29T20:00:17.215147Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "frag1.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:00:17.215147Z",
+                "accessed": "2004-02-29T20:00:17.215147Z",
+                "changed": "2004-02-29T20:00:17.215147Z",
+                "created": "2004-02-29T20:00:17.215147Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 84,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 1584,
+                "allocated_size": 2048,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4073,
+                        "length": 1
+                    },
+                    {
+                        "offset": 4075,
+                        "length": 1
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:00:17.215147Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "frag1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:17.215147Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "frag1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:17.215147Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "frag1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:17.215147Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "frag1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:17.215147Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "frag1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:40.698915Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "frag1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:40.698915Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "frag1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:40.698915Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "frag1.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "frag1.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\frag2.dat",
+        "inode": 4261,
+        "is_active": false,
+        "is_directory": false,
+        "size": 3873,
+        "standard_information": {
+            "created": "2004-02-29T20:00:29.452744Z",
+            "modified": "2004-02-29T20:02:54.891874Z",
+            "changed": "2004-02-29T20:02:54.891874Z",
+            "accessed": "2004-02-29T20:02:54.891874Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "frag2.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:00:29.452744Z",
+            "accessed": "2004-02-29T20:00:29.452744Z",
+            "changed": "2004-02-29T20:00:29.452744Z",
+            "created": "2004-02-29T20:00:29.452744Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "frag2.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:00:29.452744Z",
+                "accessed": "2004-02-29T20:00:29.452744Z",
+                "changed": "2004-02-29T20:00:29.452744Z",
+                "created": "2004-02-29T20:00:29.452744Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 84,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 3873,
+                "allocated_size": 4096,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4074,
+                        "length": 1
+                    },
+                    {
+                        "offset": 4076,
+                        "length": 2
+                    },
+                    {
+                        "offset": 4085,
+                        "length": 1
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:00:29.452744Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "frag2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:29.452744Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "frag2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:29.452744Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "frag2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:29.452744Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "frag2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:00:29.452744Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "frag2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:02:54.891874Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "frag2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:02:54.891874Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "frag2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:02:54.891874Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "frag2.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "frag2.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\sing1.dat",
+        "inode": 4262,
+        "is_active": false,
+        "is_directory": false,
+        "size": 780,
+        "standard_information": {
+            "created": "2004-02-29T20:01:24.301613Z",
+            "modified": "2004-02-29T20:01:24.321642Z",
+            "changed": "2004-02-29T20:01:24.321642Z",
+            "accessed": "2004-02-29T20:01:24.321642Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "sing1.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:01:24.301613Z",
+            "accessed": "2004-02-29T20:01:24.301613Z",
+            "changed": "2004-02-29T20:01:24.301613Z",
+            "created": "2004-02-29T20:01:24.301613Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "sing1.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:01:24.301613Z",
+                "accessed": "2004-02-29T20:01:24.301613Z",
+                "changed": "2004-02-29T20:01:24.301613Z",
+                "created": "2004-02-29T20:01:24.301613Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 84,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 780,
+                "allocated_size": 1024,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4078,
+                        "length": 1
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:01:24.301613Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "sing1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:24.301613Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "sing1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:24.301613Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "sing1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:24.301613Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "sing1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:24.301613Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "sing1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:24.321642Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "sing1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:24.321642Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "sing1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:24.321642Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "sing1.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "sing1.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\mult1.dat",
+        "inode": 4263,
+        "is_active": false,
+        "is_directory": false,
+        "size": 3801,
+        "standard_information": {
+            "created": "2004-02-29T20:01:37.360390Z",
+            "modified": "2004-02-29T20:02:22.054657Z",
+            "changed": "2004-02-29T20:02:22.054657Z",
+            "accessed": "2004-02-29T20:02:22.054657Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "mult1.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:01:37.360390Z",
+            "accessed": "2004-02-29T20:01:37.360390Z",
+            "changed": "2004-02-29T20:01:37.360390Z",
+            "created": "2004-02-29T20:01:37.360390Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "mult1.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:01:37.360390Z",
+                "accessed": "2004-02-29T20:01:37.360390Z",
+                "changed": "2004-02-29T20:01:37.360390Z",
+                "created": "2004-02-29T20:01:37.360390Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 84,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 3801,
+                "allocated_size": 4096,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4079,
+                        "length": 4
+                    }
+                ]
+            },
+            {
+                "type": "$DATA",
+                "name": "ADS",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 1234,
+                "allocated_size": 2048,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4083,
+                        "length": 2
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:01:37.360390Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:02:22.054657Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:02:22.054657Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "mult1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:02:22.054657Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "mult1.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "mult1.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\dir1",
+        "inode": 4264,
+        "is_active": false,
+        "is_directory": true,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T20:03:00.610098Z",
+            "modified": "2004-02-29T20:03:00.610098Z",
+            "changed": "2004-02-29T20:03:00.610098Z",
+            "accessed": "2004-02-29T20:03:00.610098Z",
+            "flags": [
+                "has-indx"
+            ],
+            "owner_id": 0,
+            "security_id": 261,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "dir1",
+            "flags": [
+                "has-indx"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:03:00.610098Z",
+            "accessed": "2004-02-29T20:03:00.610098Z",
+            "changed": "2004-02-29T20:03:00.610098Z",
+            "created": "2004-02-29T20:03:00.610098Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "dir1",
+                "flags": [
+                    "has-indx"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:03:00.610098Z",
+                "accessed": "2004-02-29T20:03:00.610098Z",
+                "changed": "2004-02-29T20:03:00.610098Z",
+                "created": "2004-02-29T20:03:00.610098Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 74,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$I30",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:03:00.610098Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "dir1"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:00.610098Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "dir1"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:00.610098Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "dir1"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:00.610098Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "dir1"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:00.610098Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "dir1"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:00.610098Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "dir1"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:00.610098Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "dir1"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:00.610098Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "dir1"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "dir1",
+            "$I300"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": [
+            "dir2",
+            "mult2.dat"
+        ]
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\dir2",
+        "inode": 4265,
+        "is_active": false,
+        "is_directory": true,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T20:03:03.684517Z",
+            "modified": "2004-02-29T20:03:03.684517Z",
+            "changed": "2004-02-29T20:03:03.684517Z",
+            "accessed": "2004-02-29T20:03:03.684517Z",
+            "flags": [
+                "has-indx"
+            ],
+            "owner_id": 0,
+            "security_id": 261,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "dir2",
+            "flags": [
+                "has-indx"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:03:03.684517Z",
+            "accessed": "2004-02-29T20:03:03.684517Z",
+            "changed": "2004-02-29T20:03:03.684517Z",
+            "created": "2004-02-29T20:03:03.684517Z",
+            "parent_ref": 33,
+            "parent_seq": 1
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "dir2",
+                "flags": [
+                    "has-indx"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:03:03.684517Z",
+                "accessed": "2004-02-29T20:03:03.684517Z",
+                "changed": "2004-02-29T20:03:03.684517Z",
+                "created": "2004-02-29T20:03:03.684517Z",
+                "parent_ref": 33,
+                "parent_seq": 1
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 74,
+                "runs": []
+            },
+            {
+                "type": "$INDEX ROOT",
+                "name": "$I30",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 48,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:03:03.684517Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "dir2"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:03.684517Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "dir2"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:03.684517Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "dir2"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:03.684517Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "dir2"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:03.684517Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "dir2"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:03.684517Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "dir2"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:03.684517Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "dir2"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:03.684517Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "dir2"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "dir2",
+            "$I300"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": [
+            "frag3.dat"
+        ]
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\frag3.dat",
+        "inode": 4266,
+        "is_active": false,
+        "is_directory": false,
+        "size": 2027,
+        "standard_information": {
+            "created": "2004-02-29T20:03:24.083851Z",
+            "modified": "2004-02-29T20:03:49.340168Z",
+            "changed": "2004-02-29T20:03:49.340168Z",
+            "accessed": "2004-02-29T20:03:49.340168Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "frag3.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:03:24.083851Z",
+            "accessed": "2004-02-29T20:03:24.083851Z",
+            "changed": "2004-02-29T20:03:24.083851Z",
+            "created": "2004-02-29T20:03:24.083851Z",
+            "parent_ref": 34,
+            "parent_seq": 1
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "frag3.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:03:24.083851Z",
+                "accessed": "2004-02-29T20:03:24.083851Z",
+                "changed": "2004-02-29T20:03:24.083851Z",
+                "created": "2004-02-29T20:03:24.083851Z",
+                "parent_ref": 34,
+                "parent_seq": 1
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 84,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 2027,
+                "allocated_size": 2048,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4090,
+                        "length": 1
+                    },
+                    {
+                        "offset": 4093,
+                        "length": 1
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:03:24.083851Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "frag3.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:24.083851Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "frag3.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:24.083851Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "frag3.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:24.083851Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "frag3.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:24.083851Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "frag3.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:49.340168Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "frag3.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:49.340168Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "frag3.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:49.340168Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "frag3.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "frag3.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\mult2.dat",
+        "inode": 4267,
+        "is_active": false,
+        "is_directory": false,
+        "size": 1715,
+        "standard_information": {
+            "created": "2004-02-29T20:03:38.774975Z",
+            "modified": "2004-02-29T20:03:38.795004Z",
+            "changed": "2004-02-29T20:03:38.795004Z",
+            "accessed": "2004-02-29T20:03:38.795004Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "mult2.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:03:38.774975Z",
+            "accessed": "2004-02-29T20:03:38.774975Z",
+            "changed": "2004-02-29T20:03:38.774975Z",
+            "created": "2004-02-29T20:03:38.774975Z",
+            "parent_ref": 33,
+            "parent_seq": 1
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "mult2.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:03:38.774975Z",
+                "accessed": "2004-02-29T20:03:38.774975Z",
+                "changed": "2004-02-29T20:03:38.774975Z",
+                "created": "2004-02-29T20:03:38.774975Z",
+                "parent_ref": 33,
+                "parent_seq": 1
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 84,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 1715,
+                "allocated_size": 2048,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4091,
+                        "length": 2
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:03:38.774975Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "mult2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:38.774975Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "mult2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:38.774975Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "mult2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:38.774975Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "mult2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:38.774975Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "mult2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:38.795004Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "mult2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:38.795004Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "mult2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:03:38.795004Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "mult2.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "mult2.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\res1.dat",
+        "inode": 4268,
+        "is_active": false,
+        "is_directory": false,
+        "size": 0,
+        "standard_information": {
+            "created": "2004-02-29T20:05:37.766077Z",
+            "modified": "2004-02-29T20:05:37.766077Z",
+            "changed": "2004-02-29T20:05:37.766077Z",
+            "accessed": "2004-02-29T20:05:37.766077Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "res1.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:05:37.766077Z",
+            "accessed": "2004-02-29T20:05:37.766077Z",
+            "changed": "2004-02-29T20:05:37.766077Z",
+            "created": "2004-02-29T20:05:37.766077Z",
+            "parent_ref": 5,
+            "parent_seq": 5
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "res1.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:05:37.766077Z",
+                "accessed": "2004-02-29T20:05:37.766077Z",
+                "changed": "2004-02-29T20:05:37.766077Z",
+                "created": "2004-02-29T20:05:37.766077Z",
+                "parent_ref": 5,
+                "parent_seq": 5
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 82,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 101,
+                "runs": []
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:05:37.766077Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "res1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:05:37.766077Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "res1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:05:37.766077Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "res1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:05:37.766077Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "res1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:05:37.766077Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "res1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:05:37.766077Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "res1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:05:37.766077Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "res1.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:05:37.766077Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "res1.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0",
+            "dcz8"
+        ],
+        "active_unicode_strings": [
+            "res1.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
+    },
+    {
+        "magic": 1162627398,
+        "path": "$ORPHAN\\sing2.dat",
+        "inode": 4269,
+        "is_active": false,
+        "is_directory": false,
+        "size": 1005,
+        "standard_information": {
+            "created": "2004-02-29T20:04:15.607939Z",
+            "modified": "2004-02-29T20:04:15.637981Z",
+            "changed": "2004-02-29T20:04:15.637981Z",
+            "accessed": "2004-02-29T20:04:15.637981Z",
+            "flags": [
+                "archive"
+            ],
+            "owner_id": 0,
+            "security_id": 260,
+            "quota_charged": 0,
+            "usn": 0
+        },
+        "filename_information": {
+            "type": "WIN32 + DOS 8.3",
+            "name": "sing2.dat",
+            "flags": [
+                "archive"
+            ],
+            "logical_size": 0,
+            "physical_size": 0,
+            "modified": "2004-02-29T20:04:15.607939Z",
+            "accessed": "2004-02-29T20:04:15.607939Z",
+            "changed": "2004-02-29T20:04:15.607939Z",
+            "created": "2004-02-29T20:04:15.607939Z",
+            "parent_ref": 37,
+            "parent_seq": 1
+        },
+        "owner_id": 0,
+        "security_id": 0,
+        "quota_charged": 0,
+        "usn": 0,
+        "filenames": [
+            {
+                "type": "WIN32 + DOS 8.3",
+                "name": "sing2.dat",
+                "flags": [
+                    "archive"
+                ],
+                "logical_size": 0,
+                "physical_size": 0,
+                "modified": "2004-02-29T20:04:15.607939Z",
+                "accessed": "2004-02-29T20:04:15.607939Z",
+                "changed": "2004-02-29T20:04:15.607939Z",
+                "created": "2004-02-29T20:04:15.607939Z",
+                "parent_ref": 37,
+                "parent_seq": 1
+            }
+        ],
+        "attributes": [
+            {
+                "type": "$STANDARD INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 72,
+                "runs": []
+            },
+            {
+                "type": "$FILENAME INFORMATION",
+                "name": "",
+                "flags": [],
+                "is_resident": true,
+                "data_size": 0,
+                "allocated_size": 0,
+                "value_size": 84,
+                "runs": []
+            },
+            {
+                "type": "$DATA",
+                "name": "",
+                "flags": [],
+                "is_resident": false,
+                "data_size": 1005,
+                "allocated_size": 1024,
+                "value_size": 0,
+                "runs": [
+                    {
+                        "offset": 4094,
+                        "length": 1
+                    }
+                ]
+            }
+        ],
+        "indx_entries": [],
+        "slack_indx_entries": [],
+        "timeline": [
+            {
+                "timestamp": "2004-02-29T20:04:15.607939Z",
+                "type": "birthed",
+                "source": "$SI",
+                "path": "sing2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:04:15.607939Z",
+                "type": "birthed",
+                "source": "$FN",
+                "path": "sing2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:04:15.607939Z",
+                "type": "accessed",
+                "source": "$FN",
+                "path": "sing2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:04:15.607939Z",
+                "type": "modified",
+                "source": "$FN",
+                "path": "sing2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:04:15.607939Z",
+                "type": "changed",
+                "source": "$FN",
+                "path": "sing2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:04:15.637981Z",
+                "type": "accessed",
+                "source": "$SI",
+                "path": "sing2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:04:15.637981Z",
+                "type": "modified",
+                "source": "$SI",
+                "path": "sing2.dat"
+            },
+            {
+                "timestamp": "2004-02-29T20:04:15.637981Z",
+                "type": "changed",
+                "source": "$SI",
+                "path": "sing2.dat"
+            }
+        ],
+        "active_ascii_strings": [
+            "FILE0"
+        ],
+        "active_unicode_strings": [
+            "sing2.dat"
+        ],
+        "slack_ascii_strings": [],
+        "slack_unicode_strings": []
     }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:03:24.083851Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "frag3.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:24.083851Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "frag3.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:24.083851Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "frag3.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:24.083851Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "frag3.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:24.083851Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "frag3.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:49.340168Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "frag3.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:49.340168Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "frag3.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:49.340168Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "frag3.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "frag3.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\mult2.dat",
-  "inode": 4267,
-  "is_active": false,
-  "is_directory": false,
-  "size": 1715,
-  "standard_information": {
-    "created": "2004-02-29T20:03:38.774975Z",
-    "modified": "2004-02-29T20:03:38.795004Z",
-    "changed": "2004-02-29T20:03:38.795004Z",
-    "accessed": "2004-02-29T20:03:38.795004Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "mult2.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:03:38.774975Z",
-    "accessed": "2004-02-29T20:03:38.774975Z",
-    "changed": "2004-02-29T20:03:38.774975Z",
-    "created": "2004-02-29T20:03:38.774975Z",
-    "parent_ref": 33,
-    "parent_seq": 1
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "mult2.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:03:38.774975Z",
-      "accessed": "2004-02-29T20:03:38.774975Z",
-      "changed": "2004-02-29T20:03:38.774975Z",
-      "created": "2004-02-29T20:03:38.774975Z",
-      "parent_ref": 33,
-      "parent_seq": 1
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 84,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 1715,
-      "allocated_size": 2048,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4091,
-          "length": 2
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:03:38.774975Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "mult2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:38.774975Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "mult2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:38.774975Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "mult2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:38.774975Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "mult2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:38.774975Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "mult2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:38.795004Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "mult2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:38.795004Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "mult2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:03:38.795004Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "mult2.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "mult2.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\res1.dat",
-  "inode": 4268,
-  "is_active": false,
-  "is_directory": false,
-  "size": 0,
-  "standard_information": {
-    "created": "2004-02-29T20:05:37.766077Z",
-    "modified": "2004-02-29T20:05:37.766077Z",
-    "changed": "2004-02-29T20:05:37.766077Z",
-    "accessed": "2004-02-29T20:05:37.766077Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "res1.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:05:37.766077Z",
-    "accessed": "2004-02-29T20:05:37.766077Z",
-    "changed": "2004-02-29T20:05:37.766077Z",
-    "created": "2004-02-29T20:05:37.766077Z",
-    "parent_ref": 5,
-    "parent_seq": 5
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "res1.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:05:37.766077Z",
-      "accessed": "2004-02-29T20:05:37.766077Z",
-      "changed": "2004-02-29T20:05:37.766077Z",
-      "created": "2004-02-29T20:05:37.766077Z",
-      "parent_ref": 5,
-      "parent_seq": 5
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 82,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 101,
-      "runs": []
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:05:37.766077Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "res1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:05:37.766077Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "res1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:05:37.766077Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "res1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:05:37.766077Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "res1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:05:37.766077Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "res1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:05:37.766077Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "res1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:05:37.766077Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "res1.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:05:37.766077Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "res1.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0",
-    "dcz8"
-  ],
-  "active_unicode_strings": [
-    "res1.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
-,
-{
-  "magic": 1162627398,
-  "path": "$ORPHAN\\sing2.dat",
-  "inode": 4269,
-  "is_active": false,
-  "is_directory": false,
-  "size": 1005,
-  "standard_information": {
-    "created": "2004-02-29T20:04:15.607939Z",
-    "modified": "2004-02-29T20:04:15.637981Z",
-    "changed": "2004-02-29T20:04:15.637981Z",
-    "accessed": "2004-02-29T20:04:15.637981Z",
-    "flags": [
-      "archive"
-    ],
-    "owner_id": 0,
-    "security_id": 260,
-    "quota_charged": 0,
-    "usn": 0
-  },
-  "filename_information": {
-    "type": "WIN32 + DOS 8.3",
-    "name": "sing2.dat",
-    "flags": [
-      "archive"
-    ],
-    "logical_size": 0,
-    "physical_size": 0,
-    "modified": "2004-02-29T20:04:15.607939Z",
-    "accessed": "2004-02-29T20:04:15.607939Z",
-    "changed": "2004-02-29T20:04:15.607939Z",
-    "created": "2004-02-29T20:04:15.607939Z",
-    "parent_ref": 37,
-    "parent_seq": 1
-  },
-  "owner_id": 0,
-  "security_id": 0,
-  "quota_charged": 0,
-  "usn": 0,
-  "filenames": [
-    {
-      "type": "WIN32 + DOS 8.3",
-      "name": "sing2.dat",
-      "flags": [
-        "archive"
-      ],
-      "logical_size": 0,
-      "physical_size": 0,
-      "modified": "2004-02-29T20:04:15.607939Z",
-      "accessed": "2004-02-29T20:04:15.607939Z",
-      "changed": "2004-02-29T20:04:15.607939Z",
-      "created": "2004-02-29T20:04:15.607939Z",
-      "parent_ref": 37,
-      "parent_seq": 1
-    }
-  ],
-  "attributes": [
-    {
-      "type": "$STANDARD INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 72,
-      "runs": []
-    },
-    {
-      "type": "$FILENAME INFORMATION",
-      "name": "",
-      "flags": [],
-      "is_resident": true,
-      "data_size": 0,
-      "allocated_size": 0,
-      "value_size": 84,
-      "runs": []
-    },
-    {
-      "type": "$DATA",
-      "name": "",
-      "flags": [],
-      "is_resident": false,
-      "data_size": 1005,
-      "allocated_size": 1024,
-      "value_size": 0,
-      "runs": [
-        {
-          "offset": 4094,
-          "length": 1
-        }
-      ]
-    }
-  ],
-  "indx_entries": [],
-  "slack_indx_entries": [],
-  "timeline": [
-    {
-      "timestamp": "2004-02-29T20:04:15.607939Z",
-      "type": "birthed",
-      "source": "$SI",
-      "path": "sing2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:04:15.607939Z",
-      "type": "birthed",
-      "source": "$FN",
-      "path": "sing2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:04:15.607939Z",
-      "type": "accessed",
-      "source": "$FN",
-      "path": "sing2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:04:15.607939Z",
-      "type": "modified",
-      "source": "$FN",
-      "path": "sing2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:04:15.607939Z",
-      "type": "changed",
-      "source": "$FN",
-      "path": "sing2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:04:15.637981Z",
-      "type": "accessed",
-      "source": "$SI",
-      "path": "sing2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:04:15.637981Z",
-      "type": "modified",
-      "source": "$SI",
-      "path": "sing2.dat"
-    },
-    {
-      "timestamp": "2004-02-29T20:04:15.637981Z",
-      "type": "changed",
-      "source": "$SI",
-      "path": "sing2.dat"
-    }
-  ],
-  "active_ascii_strings": [
-    "FILE0"
-  ],
-  "active_unicode_strings": [
-    "sing2.dat"
-  ],
-  "slack_ascii_strings": [],
-  "slack_unicode_strings": []
-}
 ]

--- a/tests/list_mft/out.json
+++ b/tests/list_mft/out.json
@@ -1,0 +1,6012 @@
+[
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$MFT",
+  "inode": 2005,
+  "is_active": true,
+  "is_directory": false,
+  "size": 39936,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$MFT",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 16384,
+    "physical_size": 16384,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$MFT",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 16384,
+      "physical_size": 16384,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 74,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 39936,
+      "allocated_size": 49152,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 2005,
+          "length": 16
+        },
+        {
+          "offset": 4247,
+          "length": 32
+        }
+      ]
+    },
+    {
+      "type": "$BITMAP",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 8,
+      "allocated_size": 1024,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 2004,
+          "length": 1
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$MFT"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$MFT"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$MFTMirr",
+  "inode": 2006,
+  "is_active": true,
+  "is_directory": false,
+  "size": 4096,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$MFTMirr",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 4096,
+    "physical_size": 4096,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$MFTMirr",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 4096,
+      "physical_size": 4096,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 4096,
+      "allocated_size": 4096,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4069,
+          "length": 4
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$MFTMirr"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$MFTMirr"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$LogFile",
+  "inode": 2007,
+  "is_active": true,
+  "is_directory": false,
+  "size": 2097152,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$LogFile",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 2097152,
+    "physical_size": 2097152,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$LogFile",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 2097152,
+      "physical_size": 2097152,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 2097152,
+      "allocated_size": 2097152,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 2021,
+          "length": 2048
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$LogFile"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$LogFile"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$Volume",
+  "inode": 2008,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ]
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$Volume",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Volume",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 80,
+      "runs": []
+    },
+    {
+      "type": "$OBJECT ID/$VOLUME VERSION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 16,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$VOLUME NAME",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 16,
+      "runs": []
+    },
+    {
+      "type": "$VOLUME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 12,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 0,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$Volume"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$Volume@",
+    "NTFS_DELp"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$AttrDef",
+  "inode": 2009,
+  "is_active": true,
+  "is_directory": false,
+  "size": 2560,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ]
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$AttrDef",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 36000,
+    "physical_size": 36864,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$AttrDef",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 36000,
+      "physical_size": 36864,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 2560,
+      "allocated_size": 3072,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 5249,
+          "length": 3
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$AttrDef"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$AttrDef"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$AttrDef"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$AttrDef"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$AttrDef"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$AttrDef"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$AttrDef"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$AttrDef"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$AttrDef"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "",
+  "inode": 2010,
+  "is_active": true,
+  "is_directory": true,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T20:19:31.399673Z",
+    "changed": "2004-02-29T20:19:31.399673Z",
+    "accessed": "2004-02-29T20:19:31.399673Z",
+    "flags": [
+      "hidden",
+      "system",
+      "archive"
+    ]
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": ".",
+    "flags": [
+      "hidden",
+      "system",
+      "has-indx"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": ".",
+      "flags": [
+        "hidden",
+        "system",
+        "has-indx"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 68,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 4172,
+      "allocated_size": 5120,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4113,
+          "length": 5
+        }
+      ]
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$I30",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 56,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ALLOCATION",
+      "name": "$I30",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 4096,
+      "allocated_size": 4096,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4109,
+          "length": 4
+        }
+      ]
+    },
+    {
+      "type": "$BITMAP",
+      "name": "$I30",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 8,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "."
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "."
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "."
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "."
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "."
+    },
+    {
+      "timestamp": "2004-02-29T20:19:31.399673Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "."
+    },
+    {
+      "timestamp": "2004-02-29T20:19:31.399673Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "."
+    },
+    {
+      "timestamp": "2004-02-29T20:19:31.399673Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "."
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$I300",
+    "$I30",
+    "$I30"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": [
+    "$I30",
+    "$I30"
+  ]
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$Bitmap",
+  "inode": 2011,
+  "is_active": true,
+  "is_directory": false,
+  "size": 752,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$Bitmap",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 752,
+    "physical_size": 1024,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Bitmap",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 752,
+      "physical_size": 1024,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 80,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 752,
+      "allocated_size": 1024,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4118,
+          "length": 1
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$Bitmap"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$Bitmap"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$Bitmap"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$Bitmap"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$Bitmap"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$Bitmap"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$Bitmap"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$Bitmap"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$Bitmap"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$Boot",
+  "inode": 2012,
+  "is_active": true,
+  "is_directory": false,
+  "size": 8192,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ]
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$Boot",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 8192,
+    "physical_size": 8192,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Boot",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 8192,
+      "physical_size": 8192,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 76,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 8192,
+      "allocated_size": 8192,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 0,
+          "length": 8
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$Boot"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$Boot"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$Boot"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$Boot"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$Boot"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$Boot"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$Boot"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$Boot"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$Boot"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$BadClus",
+  "inode": 2013,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$BadClus",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$BadClus",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 0,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "$Bad",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 6160384,
+      "allocated_size": 6160384,
+      "value_size": 0,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$BadClus"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$BadClus"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$BadClus"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$BadClus"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$BadClus"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$BadClus"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$BadClus"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$BadClus"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$BadClus",
+    "$Bad"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": [
+    "$Bad"
+  ]
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$Secure",
+  "inode": 2014,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system",
+      "has-view-index"
+    ],
+    "owner_id": 0,
+    "security_id": 257,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$Secure",
+    "flags": [],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": null,
+    "accessed": null,
+    "changed": null,
+    "created": null,
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Secure",
+      "flags": [],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": null,
+      "accessed": null,
+      "changed": null,
+      "created": null,
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 80,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "$SDS",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 263140,
+      "allocated_size": 263168,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4992,
+          "length": 257
+        }
+      ]
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$SDH",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 56,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$SII",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 288,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ALLOCATION",
+      "name": "$SDH",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 4096,
+      "allocated_size": 4096,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4086,
+          "length": 4
+        }
+      ]
+    },
+    {
+      "type": "$BITMAP",
+      "name": "$SDH",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 8,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": null,
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$Secure"
+    },
+    {
+      "timestamp": null,
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$Secure"
+    },
+    {
+      "timestamp": null,
+      "type": "modified",
+      "source": "$FN",
+      "path": "$Secure"
+    },
+    {
+      "timestamp": null,
+      "type": "changed",
+      "source": "$FN",
+      "path": "$Secure"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$Secure"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$Secure"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$Secure"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$Secure"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$Secure",
+    "$SDS",
+    "$SDH",
+    "$SII",
+    "$SDH",
+    "$SDH"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$UpCase",
+  "inode": 2015,
+  "is_active": true,
+  "is_directory": false,
+  "size": 131072,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$UpCase",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 131072,
+    "physical_size": 131072,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$UpCase",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 131072,
+      "physical_size": 131072,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 80,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 131072,
+      "allocated_size": 131072,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4119,
+          "length": 128
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$UpCase"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$UpCase"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$UpCase"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$UpCase"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$UpCase"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$UpCase"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$UpCase"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$UpCase"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$UpCase"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$Extend",
+  "inode": 2016,
+  "is_active": true,
+  "is_directory": true,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 257,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$Extend",
+    "flags": [
+      "hidden",
+      "system",
+      "has-indx"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Extend",
+      "flags": [
+        "hidden",
+        "system",
+        "has-indx"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 80,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$I30",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 344,
+      "runs": []
+    }
+  ],
+  "indx_entries": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$ObjId",
+      "flags": [
+        "hidden",
+        "system",
+        "archive",
+        "has-view-index"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:58:04.062469Z",
+      "accessed": "2004-02-29T19:58:04.062469Z",
+      "changed": "2004-02-29T19:58:04.062469Z",
+      "created": "2004-02-29T19:58:04.062469Z",
+      "parent_ref": 11,
+      "parent_seq": 11,
+      "inode": 25,
+      "sequence_num": 1
+    },
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Quota",
+      "flags": [
+        "hidden",
+        "system",
+        "archive",
+        "has-view-index"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:58:04.062469Z",
+      "accessed": "2004-02-29T19:58:04.062469Z",
+      "changed": "2004-02-29T19:58:04.062469Z",
+      "created": "2004-02-29T19:58:04.062469Z",
+      "parent_ref": 11,
+      "parent_seq": 11,
+      "inode": 24,
+      "sequence_num": 1
+    },
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Reparse",
+      "flags": [
+        "hidden",
+        "system",
+        "archive",
+        "has-view-index"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:58:04.062469Z",
+      "accessed": "2004-02-29T19:58:04.062469Z",
+      "changed": "2004-02-29T19:58:04.062469Z",
+      "created": "2004-02-29T19:58:04.062469Z",
+      "parent_ref": 11,
+      "parent_seq": 11,
+      "inode": 26,
+      "sequence_num": 1
+    }
+  ],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$Extend"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$Extend"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$Extend"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$Extend"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$Extend"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$Extend"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$Extend"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$Extend"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "INDX",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "INDX",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "INDX",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "INDX",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "INDX",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "INDX",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "INDX",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "INDX",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "INDX",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "INDX",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "INDX",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "INDX",
+      "path": "$Reparse"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$Extend",
+    "$I300",
+    "$ObjId",
+    "$Quota",
+    "$Reparse"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": [
+    "$Reparse"
+  ]
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 2017,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ]
+  },
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 0,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 2018,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ]
+  },
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 0,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 2019,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ]
+  },
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 0,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 2020,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ]
+  },
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 0,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\mult1.dat",
+  "inode": 2167,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T20:01:37.360390Z",
+    "modified": "2004-02-29T20:01:37.360390Z",
+    "changed": "2004-02-29T20:01:37.360390Z",
+    "accessed": "2004-02-29T20:01:37.360390Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "mult1.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:01:37.360390Z",
+    "accessed": "2004-02-29T20:01:37.360390Z",
+    "changed": "2004-02-29T20:01:37.360390Z",
+    "created": "2004-02-29T20:01:37.360390Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "mult1.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:01:37.360390Z",
+      "accessed": "2004-02-29T20:01:37.360390Z",
+      "changed": "2004-02-29T20:01:37.360390Z",
+      "created": "2004-02-29T20:01:37.360390Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 84,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 0,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "mult1.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "mult1.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$MFT",
+  "inode": 4069,
+  "is_active": true,
+  "is_directory": false,
+  "size": 39936,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$MFT",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 16384,
+    "physical_size": 16384,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$MFT",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 16384,
+      "physical_size": 16384,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 74,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 39936,
+      "allocated_size": 49152,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 2005,
+          "length": 16
+        },
+        {
+          "offset": 4247,
+          "length": 32
+        }
+      ]
+    },
+    {
+      "type": "$BITMAP",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 8,
+      "allocated_size": 1024,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 2004,
+          "length": 1
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$MFT"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$MFT"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$MFT"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$MFTMirr",
+  "inode": 4070,
+  "is_active": true,
+  "is_directory": false,
+  "size": 4096,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$MFTMirr",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 4096,
+    "physical_size": 4096,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$MFTMirr",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 4096,
+      "physical_size": 4096,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 4096,
+      "allocated_size": 4096,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4069,
+          "length": 4
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$MFTMirr"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$MFTMirr"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$MFTMirr"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$LogFile",
+  "inode": 4071,
+  "is_active": true,
+  "is_directory": false,
+  "size": 2097152,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 256,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$LogFile",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 2097152,
+    "physical_size": 2097152,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$LogFile",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 2097152,
+      "physical_size": 2097152,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 2097152,
+      "allocated_size": 2097152,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 2021,
+          "length": 2048
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$LogFile"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$LogFile"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$LogFile"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$Volume",
+  "inode": 4072,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:57:57.513052Z",
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "flags": [
+      "hidden",
+      "system"
+    ]
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$Volume",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:57:57.513052Z",
+    "accessed": "2004-02-29T19:57:57.513052Z",
+    "changed": "2004-02-29T19:57:57.513052Z",
+    "created": "2004-02-29T19:57:57.513052Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Volume",
+      "flags": [
+        "hidden",
+        "system"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:57:57.513052Z",
+      "accessed": "2004-02-29T19:57:57.513052Z",
+      "changed": "2004-02-29T19:57:57.513052Z",
+      "created": "2004-02-29T19:57:57.513052Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 80,
+      "runs": []
+    },
+    {
+      "type": "$OBJECT ID/$VOLUME VERSION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 16,
+      "runs": []
+    },
+    {
+      "type": "$SECURITY DESCRIPTOR",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$VOLUME NAME",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 16,
+      "runs": []
+    },
+    {
+      "type": "$VOLUME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 12,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 0,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$Volume"
+    },
+    {
+      "timestamp": "2004-02-29T19:57:57.513052Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$Volume"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$Volume@",
+    "NTFS_DELp"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 4247,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": null,
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 4248,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": null,
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 4249,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": null,
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 4250,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": null,
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 4251,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": null,
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 4252,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": null,
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 4253,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": null,
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "??",
+  "inode": 4254,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": null,
+  "filename_information": null,
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [],
+  "attributes": [],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$Quota",
+  "inode": 4255,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:58:04.062469Z",
+    "modified": "2004-02-29T19:58:04.062469Z",
+    "changed": "2004-02-29T19:58:04.062469Z",
+    "accessed": "2004-02-29T19:58:04.062469Z",
+    "flags": [
+      "hidden",
+      "system",
+      "archive",
+      "has-view-index"
+    ],
+    "owner_id": 0,
+    "security_id": 257,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$Quota",
+    "flags": [
+      "hidden",
+      "system",
+      "archive",
+      "has-view-index"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:58:04.062469Z",
+    "accessed": "2004-02-29T19:58:04.062469Z",
+    "changed": "2004-02-29T19:58:04.062469Z",
+    "created": "2004-02-29T19:58:04.062469Z",
+    "parent_ref": 11,
+    "parent_seq": 11
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Quota",
+      "flags": [
+        "hidden",
+        "system",
+        "archive",
+        "has-view-index"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:58:04.062469Z",
+      "accessed": "2004-02-29T19:58:04.062469Z",
+      "changed": "2004-02-29T19:58:04.062469Z",
+      "created": "2004-02-29T19:58:04.062469Z",
+      "parent_ref": 11,
+      "parent_seq": 11
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 78,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$O",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 88,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$Q",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 208,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$Quota"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$Quota"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$Quota"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$ObjId",
+  "inode": 4256,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:58:04.062469Z",
+    "modified": "2004-02-29T19:58:04.062469Z",
+    "changed": "2004-02-29T19:58:04.062469Z",
+    "accessed": "2004-02-29T19:58:04.062469Z",
+    "flags": [
+      "hidden",
+      "system",
+      "archive",
+      "has-view-index"
+    ],
+    "owner_id": 0,
+    "security_id": 257,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$ObjId",
+    "flags": [
+      "hidden",
+      "system",
+      "archive",
+      "has-view-index"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:58:04.062469Z",
+    "accessed": "2004-02-29T19:58:04.062469Z",
+    "changed": "2004-02-29T19:58:04.062469Z",
+    "created": "2004-02-29T19:58:04.062469Z",
+    "parent_ref": 11,
+    "parent_seq": 11
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$ObjId",
+      "flags": [
+        "hidden",
+        "system",
+        "archive",
+        "has-view-index"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:58:04.062469Z",
+      "accessed": "2004-02-29T19:58:04.062469Z",
+      "changed": "2004-02-29T19:58:04.062469Z",
+      "created": "2004-02-29T19:58:04.062469Z",
+      "parent_ref": 11,
+      "parent_seq": 11
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 78,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$O",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 136,
+      "runs": []
+    }
+  ],
+  "indx_entries": [
+    {
+      "type": "POSIX",
+      "name": "",
+      "flags": [],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "1603-09-05T08:14:53.013197Z",
+      "accessed": null,
+      "changed": null,
+      "created": "1970-01-01T00:00:00Z",
+      "parent_ref": 268755454544440,
+      "parent_seq": 17784,
+      "inode": 3670048,
+      "sequence_num": 0
+    }
+  ],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "1603-09-05T08:14:53.013197Z",
+      "type": "modified",
+      "source": "INDX",
+      "path": ""
+    },
+    {
+      "timestamp": "1970-01-01T00:00:00Z",
+      "type": "birthed",
+      "source": "INDX",
+      "path": ""
+    },
+    {
+      "timestamp": null,
+      "type": "accessed",
+      "source": "INDX",
+      "path": ""
+    },
+    {
+      "timestamp": null,
+      "type": "changed",
+      "source": "INDX",
+      "path": ""
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$ObjId"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$ObjId"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$ObjId"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\$Reparse",
+  "inode": 4257,
+  "is_active": true,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:58:04.062469Z",
+    "modified": "2004-02-29T19:58:04.062469Z",
+    "changed": "2004-02-29T19:58:04.062469Z",
+    "accessed": "2004-02-29T19:58:04.062469Z",
+    "flags": [
+      "hidden",
+      "system",
+      "archive",
+      "has-view-index"
+    ],
+    "owner_id": 0,
+    "security_id": 257,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "$Reparse",
+    "flags": [
+      "hidden",
+      "system",
+      "archive",
+      "has-view-index"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:58:04.062469Z",
+    "accessed": "2004-02-29T19:58:04.062469Z",
+    "changed": "2004-02-29T19:58:04.062469Z",
+    "created": "2004-02-29T19:58:04.062469Z",
+    "parent_ref": 11,
+    "parent_seq": 11
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "$Reparse",
+      "flags": [
+        "hidden",
+        "system",
+        "archive",
+        "has-view-index"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:58:04.062469Z",
+      "accessed": "2004-02-29T19:58:04.062469Z",
+      "changed": "2004-02-29T19:58:04.062469Z",
+      "created": "2004-02-29T19:58:04.062469Z",
+      "parent_ref": 11,
+      "parent_seq": 11
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$R",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "$Reparse"
+    },
+    {
+      "timestamp": "2004-02-29T19:58:04.062469Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "$Reparse"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "$Reparse"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\System Volume Information",
+  "inode": 4258,
+  "is_active": true,
+  "is_directory": true,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T19:59:10.189751Z",
+    "modified": "2004-02-29T19:59:11.191191Z",
+    "changed": "2004-02-29T19:59:11.191191Z",
+    "accessed": "2004-02-29T20:18:36.351355Z",
+    "flags": [
+      "hidden",
+      "system"
+    ],
+    "owner_id": 0,
+    "security_id": 258,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32",
+    "name": "System Volume Information",
+    "flags": [
+      "hidden",
+      "system",
+      "has-indx"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T19:59:10.189751Z",
+    "accessed": "2004-02-29T19:59:10.189751Z",
+    "changed": "2004-02-29T19:59:10.189751Z",
+    "created": "2004-02-29T19:59:10.189751Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "DOS 8.3",
+      "name": "SYSTEM~1",
+      "flags": [
+        "hidden",
+        "system",
+        "has-indx"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:59:10.189751Z",
+      "accessed": "2004-02-29T19:59:10.189751Z",
+      "changed": "2004-02-29T19:59:10.189751Z",
+      "created": "2004-02-29T19:59:10.189751Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    },
+    {
+      "type": "WIN32",
+      "name": "System Volume Information",
+      "flags": [
+        "hidden",
+        "system",
+        "has-indx"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T19:59:10.189751Z",
+      "accessed": "2004-02-29T19:59:10.189751Z",
+      "changed": "2004-02-29T19:59:10.189751Z",
+      "created": "2004-02-29T19:59:10.189751Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 116,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$I30",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 160,
+      "runs": []
+    }
+  ],
+  "indx_entries": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "tracking.log",
+      "flags": [
+        "hidden",
+        "system",
+        "archive"
+      ],
+      "logical_size": 20480,
+      "physical_size": 20480,
+      "modified": "2004-02-29T20:06:12.766405Z",
+      "accessed": "2004-02-29T20:06:12.766405Z",
+      "changed": "2004-02-29T20:06:12.766405Z",
+      "created": "2004-02-29T19:59:10.239822Z",
+      "parent_ref": 27,
+      "parent_seq": 1,
+      "inode": 28,
+      "sequence_num": 2
+    }
+  ],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "System Volume Information"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "SYSTEM~1"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "SYSTEM~1"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "SYSTEM~1"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "SYSTEM~1"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "System Volume Information"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "System Volume Information"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "System Volume Information"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.189751Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "System Volume Information"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.239822Z",
+      "type": "birthed",
+      "source": "INDX",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:11.191191Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "System Volume Information"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:11.191191Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "System Volume Information"
+    },
+    {
+      "timestamp": "2004-02-29T20:06:12.766405Z",
+      "type": "accessed",
+      "source": "INDX",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T20:06:12.766405Z",
+      "type": "modified",
+      "source": "INDX",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T20:06:12.766405Z",
+      "type": "changed",
+      "source": "INDX",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T20:18:36.351355Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "System Volume Information"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "SYSTEM~1olu0",
+    "System Volume Information",
+    "$I300",
+    "tracking.log"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": [
+    "TRACKI~1.TMP"
+  ]
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\tracking.log",
+  "inode": 4259,
+  "is_active": true,
+  "is_directory": false,
+  "size": 20480,
+  "standard_information": {
+    "created": "2004-02-29T19:59:10.239822Z",
+    "modified": "2004-02-29T20:06:12.766405Z",
+    "changed": "2004-02-29T20:06:12.766405Z",
+    "accessed": "2004-02-29T20:06:12.766405Z",
+    "flags": [
+      "hidden",
+      "system",
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 259,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "tracking.log",
+    "flags": [
+      "hidden",
+      "system",
+      "archive"
+    ],
+    "logical_size": 20480,
+    "physical_size": 20480,
+    "modified": "2004-02-29T19:59:11.191191Z",
+    "accessed": "2004-02-29T19:59:11.191191Z",
+    "changed": "2004-02-29T19:59:11.191191Z",
+    "created": "2004-02-29T19:59:10.239822Z",
+    "parent_ref": 27,
+    "parent_seq": 1
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "tracking.log",
+      "flags": [
+        "hidden",
+        "system",
+        "archive"
+      ],
+      "logical_size": 20480,
+      "physical_size": 20480,
+      "modified": "2004-02-29T19:59:11.191191Z",
+      "accessed": "2004-02-29T19:59:11.191191Z",
+      "changed": "2004-02-29T19:59:11.191191Z",
+      "created": "2004-02-29T19:59:10.239822Z",
+      "parent_ref": 27,
+      "parent_seq": 1
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 90,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 20480,
+      "allocated_size": 20480,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 5252,
+          "length": 20
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T19:59:10.239822Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:10.239822Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:11.191191Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:11.191191Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T19:59:11.191191Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T20:06:12.766405Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T20:06:12.766405Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "tracking.log"
+    },
+    {
+      "timestamp": "2004-02-29T20:06:12.766405Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "tracking.log"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "tracking.log.tm"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": [
+    "tracking.log.tmp"
+  ]
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\frag1.dat",
+  "inode": 4260,
+  "is_active": false,
+  "is_directory": false,
+  "size": 1584,
+  "standard_information": {
+    "created": "2004-02-29T20:00:17.215147Z",
+    "modified": "2004-02-29T20:00:40.698915Z",
+    "changed": "2004-02-29T20:00:40.698915Z",
+    "accessed": "2004-02-29T20:00:40.698915Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "frag1.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:00:17.215147Z",
+    "accessed": "2004-02-29T20:00:17.215147Z",
+    "changed": "2004-02-29T20:00:17.215147Z",
+    "created": "2004-02-29T20:00:17.215147Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "frag1.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:00:17.215147Z",
+      "accessed": "2004-02-29T20:00:17.215147Z",
+      "changed": "2004-02-29T20:00:17.215147Z",
+      "created": "2004-02-29T20:00:17.215147Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 84,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 1584,
+      "allocated_size": 2048,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4073,
+          "length": 1
+        },
+        {
+          "offset": 4075,
+          "length": 1
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:00:17.215147Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "frag1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:17.215147Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "frag1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:17.215147Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "frag1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:17.215147Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "frag1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:17.215147Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "frag1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:40.698915Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "frag1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:40.698915Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "frag1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:40.698915Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "frag1.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "frag1.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\frag2.dat",
+  "inode": 4261,
+  "is_active": false,
+  "is_directory": false,
+  "size": 3873,
+  "standard_information": {
+    "created": "2004-02-29T20:00:29.452744Z",
+    "modified": "2004-02-29T20:02:54.891874Z",
+    "changed": "2004-02-29T20:02:54.891874Z",
+    "accessed": "2004-02-29T20:02:54.891874Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "frag2.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:00:29.452744Z",
+    "accessed": "2004-02-29T20:00:29.452744Z",
+    "changed": "2004-02-29T20:00:29.452744Z",
+    "created": "2004-02-29T20:00:29.452744Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "frag2.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:00:29.452744Z",
+      "accessed": "2004-02-29T20:00:29.452744Z",
+      "changed": "2004-02-29T20:00:29.452744Z",
+      "created": "2004-02-29T20:00:29.452744Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 84,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 3873,
+      "allocated_size": 4096,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4074,
+          "length": 1
+        },
+        {
+          "offset": 4076,
+          "length": 2
+        },
+        {
+          "offset": 4085,
+          "length": 1
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:00:29.452744Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "frag2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:29.452744Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "frag2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:29.452744Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "frag2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:29.452744Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "frag2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:00:29.452744Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "frag2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:02:54.891874Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "frag2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:02:54.891874Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "frag2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:02:54.891874Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "frag2.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "frag2.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\sing1.dat",
+  "inode": 4262,
+  "is_active": false,
+  "is_directory": false,
+  "size": 780,
+  "standard_information": {
+    "created": "2004-02-29T20:01:24.301613Z",
+    "modified": "2004-02-29T20:01:24.321642Z",
+    "changed": "2004-02-29T20:01:24.321642Z",
+    "accessed": "2004-02-29T20:01:24.321642Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "sing1.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:01:24.301613Z",
+    "accessed": "2004-02-29T20:01:24.301613Z",
+    "changed": "2004-02-29T20:01:24.301613Z",
+    "created": "2004-02-29T20:01:24.301613Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "sing1.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:01:24.301613Z",
+      "accessed": "2004-02-29T20:01:24.301613Z",
+      "changed": "2004-02-29T20:01:24.301613Z",
+      "created": "2004-02-29T20:01:24.301613Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 84,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 780,
+      "allocated_size": 1024,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4078,
+          "length": 1
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:01:24.301613Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "sing1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:24.301613Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "sing1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:24.301613Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "sing1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:24.301613Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "sing1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:24.301613Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "sing1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:24.321642Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "sing1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:24.321642Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "sing1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:24.321642Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "sing1.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "sing1.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\mult1.dat",
+  "inode": 4263,
+  "is_active": false,
+  "is_directory": false,
+  "size": 3801,
+  "standard_information": {
+    "created": "2004-02-29T20:01:37.360390Z",
+    "modified": "2004-02-29T20:02:22.054657Z",
+    "changed": "2004-02-29T20:02:22.054657Z",
+    "accessed": "2004-02-29T20:02:22.054657Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "mult1.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:01:37.360390Z",
+    "accessed": "2004-02-29T20:01:37.360390Z",
+    "changed": "2004-02-29T20:01:37.360390Z",
+    "created": "2004-02-29T20:01:37.360390Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "mult1.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:01:37.360390Z",
+      "accessed": "2004-02-29T20:01:37.360390Z",
+      "changed": "2004-02-29T20:01:37.360390Z",
+      "created": "2004-02-29T20:01:37.360390Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 84,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 3801,
+      "allocated_size": 4096,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4079,
+          "length": 4
+        }
+      ]
+    },
+    {
+      "type": "$DATA",
+      "name": "ADS",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 1234,
+      "allocated_size": 2048,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4083,
+          "length": 2
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:01:37.360390Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:02:22.054657Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:02:22.054657Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "mult1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:02:22.054657Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "mult1.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "mult1.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\dir1",
+  "inode": 4264,
+  "is_active": false,
+  "is_directory": true,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T20:03:00.610098Z",
+    "modified": "2004-02-29T20:03:00.610098Z",
+    "changed": "2004-02-29T20:03:00.610098Z",
+    "accessed": "2004-02-29T20:03:00.610098Z",
+    "flags": [
+      "has-indx"
+    ],
+    "owner_id": 0,
+    "security_id": 261,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "dir1",
+    "flags": [
+      "has-indx"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:03:00.610098Z",
+    "accessed": "2004-02-29T20:03:00.610098Z",
+    "changed": "2004-02-29T20:03:00.610098Z",
+    "created": "2004-02-29T20:03:00.610098Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "dir1",
+      "flags": [
+        "has-indx"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:03:00.610098Z",
+      "accessed": "2004-02-29T20:03:00.610098Z",
+      "changed": "2004-02-29T20:03:00.610098Z",
+      "created": "2004-02-29T20:03:00.610098Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 74,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$I30",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:03:00.610098Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "dir1"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:00.610098Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "dir1"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:00.610098Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "dir1"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:00.610098Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "dir1"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:00.610098Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "dir1"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:00.610098Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "dir1"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:00.610098Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "dir1"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:00.610098Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "dir1"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "dir1",
+    "$I300"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": [
+    "dir2",
+    "mult2.dat"
+  ]
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\dir2",
+  "inode": 4265,
+  "is_active": false,
+  "is_directory": true,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T20:03:03.684517Z",
+    "modified": "2004-02-29T20:03:03.684517Z",
+    "changed": "2004-02-29T20:03:03.684517Z",
+    "accessed": "2004-02-29T20:03:03.684517Z",
+    "flags": [
+      "has-indx"
+    ],
+    "owner_id": 0,
+    "security_id": 261,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "dir2",
+    "flags": [
+      "has-indx"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:03:03.684517Z",
+    "accessed": "2004-02-29T20:03:03.684517Z",
+    "changed": "2004-02-29T20:03:03.684517Z",
+    "created": "2004-02-29T20:03:03.684517Z",
+    "parent_ref": 33,
+    "parent_seq": 1
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "dir2",
+      "flags": [
+        "has-indx"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:03:03.684517Z",
+      "accessed": "2004-02-29T20:03:03.684517Z",
+      "changed": "2004-02-29T20:03:03.684517Z",
+      "created": "2004-02-29T20:03:03.684517Z",
+      "parent_ref": 33,
+      "parent_seq": 1
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 74,
+      "runs": []
+    },
+    {
+      "type": "$INDEX ROOT",
+      "name": "$I30",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 48,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:03:03.684517Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "dir2"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:03.684517Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "dir2"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:03.684517Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "dir2"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:03.684517Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "dir2"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:03.684517Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "dir2"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:03.684517Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "dir2"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:03.684517Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "dir2"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:03.684517Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "dir2"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "dir2",
+    "$I300"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": [
+    "frag3.dat"
+  ]
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\frag3.dat",
+  "inode": 4266,
+  "is_active": false,
+  "is_directory": false,
+  "size": 2027,
+  "standard_information": {
+    "created": "2004-02-29T20:03:24.083851Z",
+    "modified": "2004-02-29T20:03:49.340168Z",
+    "changed": "2004-02-29T20:03:49.340168Z",
+    "accessed": "2004-02-29T20:03:49.340168Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "frag3.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:03:24.083851Z",
+    "accessed": "2004-02-29T20:03:24.083851Z",
+    "changed": "2004-02-29T20:03:24.083851Z",
+    "created": "2004-02-29T20:03:24.083851Z",
+    "parent_ref": 34,
+    "parent_seq": 1
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "frag3.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:03:24.083851Z",
+      "accessed": "2004-02-29T20:03:24.083851Z",
+      "changed": "2004-02-29T20:03:24.083851Z",
+      "created": "2004-02-29T20:03:24.083851Z",
+      "parent_ref": 34,
+      "parent_seq": 1
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 84,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 2027,
+      "allocated_size": 2048,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4090,
+          "length": 1
+        },
+        {
+          "offset": 4093,
+          "length": 1
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:03:24.083851Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "frag3.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:24.083851Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "frag3.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:24.083851Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "frag3.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:24.083851Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "frag3.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:24.083851Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "frag3.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:49.340168Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "frag3.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:49.340168Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "frag3.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:49.340168Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "frag3.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "frag3.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\mult2.dat",
+  "inode": 4267,
+  "is_active": false,
+  "is_directory": false,
+  "size": 1715,
+  "standard_information": {
+    "created": "2004-02-29T20:03:38.774975Z",
+    "modified": "2004-02-29T20:03:38.795004Z",
+    "changed": "2004-02-29T20:03:38.795004Z",
+    "accessed": "2004-02-29T20:03:38.795004Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "mult2.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:03:38.774975Z",
+    "accessed": "2004-02-29T20:03:38.774975Z",
+    "changed": "2004-02-29T20:03:38.774975Z",
+    "created": "2004-02-29T20:03:38.774975Z",
+    "parent_ref": 33,
+    "parent_seq": 1
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "mult2.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:03:38.774975Z",
+      "accessed": "2004-02-29T20:03:38.774975Z",
+      "changed": "2004-02-29T20:03:38.774975Z",
+      "created": "2004-02-29T20:03:38.774975Z",
+      "parent_ref": 33,
+      "parent_seq": 1
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 84,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 1715,
+      "allocated_size": 2048,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4091,
+          "length": 2
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:03:38.774975Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "mult2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:38.774975Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "mult2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:38.774975Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "mult2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:38.774975Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "mult2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:38.774975Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "mult2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:38.795004Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "mult2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:38.795004Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "mult2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:03:38.795004Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "mult2.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "mult2.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\res1.dat",
+  "inode": 4268,
+  "is_active": false,
+  "is_directory": false,
+  "size": 0,
+  "standard_information": {
+    "created": "2004-02-29T20:05:37.766077Z",
+    "modified": "2004-02-29T20:05:37.766077Z",
+    "changed": "2004-02-29T20:05:37.766077Z",
+    "accessed": "2004-02-29T20:05:37.766077Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "res1.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:05:37.766077Z",
+    "accessed": "2004-02-29T20:05:37.766077Z",
+    "changed": "2004-02-29T20:05:37.766077Z",
+    "created": "2004-02-29T20:05:37.766077Z",
+    "parent_ref": 5,
+    "parent_seq": 5
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "res1.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:05:37.766077Z",
+      "accessed": "2004-02-29T20:05:37.766077Z",
+      "changed": "2004-02-29T20:05:37.766077Z",
+      "created": "2004-02-29T20:05:37.766077Z",
+      "parent_ref": 5,
+      "parent_seq": 5
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 82,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 101,
+      "runs": []
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:05:37.766077Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "res1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:05:37.766077Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "res1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:05:37.766077Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "res1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:05:37.766077Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "res1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:05:37.766077Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "res1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:05:37.766077Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "res1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:05:37.766077Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "res1.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:05:37.766077Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "res1.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0",
+    "dcz8"
+  ],
+  "active_unicode_strings": [
+    "res1.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+,
+{
+  "magic": 1162627398,
+  "path": "$ORPHAN\\sing2.dat",
+  "inode": 4269,
+  "is_active": false,
+  "is_directory": false,
+  "size": 1005,
+  "standard_information": {
+    "created": "2004-02-29T20:04:15.607939Z",
+    "modified": "2004-02-29T20:04:15.637981Z",
+    "changed": "2004-02-29T20:04:15.637981Z",
+    "accessed": "2004-02-29T20:04:15.637981Z",
+    "flags": [
+      "archive"
+    ],
+    "owner_id": 0,
+    "security_id": 260,
+    "quota_charged": 0,
+    "usn": 0
+  },
+  "filename_information": {
+    "type": "WIN32 + DOS 8.3",
+    "name": "sing2.dat",
+    "flags": [
+      "archive"
+    ],
+    "logical_size": 0,
+    "physical_size": 0,
+    "modified": "2004-02-29T20:04:15.607939Z",
+    "accessed": "2004-02-29T20:04:15.607939Z",
+    "changed": "2004-02-29T20:04:15.607939Z",
+    "created": "2004-02-29T20:04:15.607939Z",
+    "parent_ref": 37,
+    "parent_seq": 1
+  },
+  "owner_id": 0,
+  "security_id": 0,
+  "quota_charged": 0,
+  "usn": 0,
+  "filenames": [
+    {
+      "type": "WIN32 + DOS 8.3",
+      "name": "sing2.dat",
+      "flags": [
+        "archive"
+      ],
+      "logical_size": 0,
+      "physical_size": 0,
+      "modified": "2004-02-29T20:04:15.607939Z",
+      "accessed": "2004-02-29T20:04:15.607939Z",
+      "changed": "2004-02-29T20:04:15.607939Z",
+      "created": "2004-02-29T20:04:15.607939Z",
+      "parent_ref": 37,
+      "parent_seq": 1
+    }
+  ],
+  "attributes": [
+    {
+      "type": "$STANDARD INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 72,
+      "runs": []
+    },
+    {
+      "type": "$FILENAME INFORMATION",
+      "name": "",
+      "flags": [],
+      "is_resident": true,
+      "data_size": 0,
+      "allocated_size": 0,
+      "value_size": 84,
+      "runs": []
+    },
+    {
+      "type": "$DATA",
+      "name": "",
+      "flags": [],
+      "is_resident": false,
+      "data_size": 1005,
+      "allocated_size": 1024,
+      "value_size": 0,
+      "runs": [
+        {
+          "offset": 4094,
+          "length": 1
+        }
+      ]
+    }
+  ],
+  "indx_entries": [],
+  "slack_indx_entries": [],
+  "timeline": [
+    {
+      "timestamp": "2004-02-29T20:04:15.607939Z",
+      "type": "birthed",
+      "source": "$SI",
+      "path": "sing2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:04:15.607939Z",
+      "type": "birthed",
+      "source": "$FN",
+      "path": "sing2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:04:15.607939Z",
+      "type": "accessed",
+      "source": "$FN",
+      "path": "sing2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:04:15.607939Z",
+      "type": "modified",
+      "source": "$FN",
+      "path": "sing2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:04:15.607939Z",
+      "type": "changed",
+      "source": "$FN",
+      "path": "sing2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:04:15.637981Z",
+      "type": "accessed",
+      "source": "$SI",
+      "path": "sing2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:04:15.637981Z",
+      "type": "modified",
+      "source": "$SI",
+      "path": "sing2.dat"
+    },
+    {
+      "timestamp": "2004-02-29T20:04:15.637981Z",
+      "type": "changed",
+      "source": "$SI",
+      "path": "sing2.dat"
+    }
+  ],
+  "active_ascii_strings": [
+    "FILE0"
+  ],
+  "active_unicode_strings": [
+    "sing2.dat"
+  ],
+  "slack_ascii_strings": [],
+  "slack_unicode_strings": []
+}
+]


### PR DESCRIPTION
This patch series further exercises the Make framework, adding command-line demonstrations against the sample data embedded with #65 .

This first command exercise catches and fixes a bug in `list_mft.py`'s JSON output.