### PR TITLE
Add `flake8` to `pre-commit` review

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,7 @@ repos:
     rev: 23.7.0
     hooks:
     -   id: black
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/indxparse/BinaryParser.py
+++ b/indxparse/BinaryParser.py
@@ -277,7 +277,7 @@ def dosdate(dosdate: array.array, dostime: array.array) -> datetime:
         hour = (t & 0b1111100000000000) >> 11
 
         return datetime(year, month, day, hour, minute, sec)
-    except:
+    except ValueError:
         return datetime.min
 
 

--- a/indxparse/BinaryParser.py
+++ b/indxparse/BinaryParser.py
@@ -1054,7 +1054,7 @@ class Nestable(object):
         @rtype: int
         @return The length of the Block starting at the given location.
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def __len__(self):
         """
@@ -1065,4 +1065,4 @@ class Nestable(object):
         @rtype: int
         @return The length of this Block in bytes.
         """
-        raise NotImplemented
+        raise NotImplementedError

--- a/indxparse/BinaryParser.py
+++ b/indxparse/BinaryParser.py
@@ -479,8 +479,6 @@ class Block(object):
             if not issubclass(type_, Nestable):
                 raise TypeError("Invalid nested structure")
 
-            typename = type_.__name__
-
             if count == 0:
 
                 def no_class_handler():

--- a/indxparse/BinaryParser.py
+++ b/indxparse/BinaryParser.py
@@ -623,7 +623,7 @@ class Block(object):
         @return: None
         """
 
-        if type(typename) == type:
+        if isinstance(typename, type):
             typename = typename.__name__
         self._declared_fields.append(
             {

--- a/indxparse/FileMap.py
+++ b/indxparse/FileMap.py
@@ -6,7 +6,6 @@
 import sys
 from collections import OrderedDict
 from struct import calcsize
-from struct import unpack_from as old_unpack
 from struct import unpack_from as old_unpack_from
 
 # From: http://code.activestate.com/recipes/577197-sortedcollection/
@@ -445,17 +444,6 @@ def unpack_from(fmt, buffer, off=0):
     size = calcsize(fmt)
     buf = buffer[off : off + size]
     return old_unpack_from(fmt, buf, 0x0)
-
-
-def unpack(fmt, string):
-    """
-    Like the shimmed unpack_from, but for struct.unpack.
-    """
-    if not isinstance(buffer, FileMap):
-        return old_unpack(fmt, string)
-    size = calcsize(fmt)
-    buf = string[:size]
-    return old_unpack(fmt, buf, 0x0)
 
 
 def struct_test():

--- a/indxparse/MFT.py
+++ b/indxparse/MFT.py
@@ -241,7 +241,7 @@ class MFT_INDEX_ENTRY(Block, Nestable):
         future_date = datetime(2025, 1, 1, 0, 0, 0)
         try:
             fn = self.filename_information()
-        except:
+        except Exception:
             return False
         if not fn:
             return False
@@ -607,7 +607,7 @@ class SlackIndexEntry(IndexEntry):
         future_date = datetime(2025, 1, 1, 0, 0, 0)
         try:
             fn = self.filename_information()
-        except:
+        except Exception:
             return False
         if not fn:
             return False

--- a/indxparse/MFT.py
+++ b/indxparse/MFT.py
@@ -1656,7 +1656,7 @@ class MFTEnumerator(object):
             yield record, path
 
     def get_path(self, record: MFTRecord) -> str:
-        """
+        r"""
         @type record: MFTRecord
         @rtype: str
         @return: A string containing the path of the given record. It will begin with the first
@@ -1780,7 +1780,7 @@ class MFTTree(object):
 
         if record_num == ROOT_INDEX:
             self._nodes[ROOT_INDEX] = MFTTreeNode(
-                self._nodes, ROOT_INDEX, "\.", ROOT_INDEX
+                self._nodes, ROOT_INDEX, r"\.", ROOT_INDEX
             )
             return
 

--- a/indxparse/MFTView.py
+++ b/indxparse/MFTView.py
@@ -27,6 +27,7 @@
 import array
 import re
 import sys
+from string import printable
 
 import wx  # type: ignore
 import wx.lib.newevent  # type: ignore
@@ -665,7 +666,7 @@ class RecordPane(scrolled.ScrolledPanel):
         print("Warning: Unbound Record Pane update")
 
 
-ascii_byte = " !\"#\$%&'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}\\\~"
+ascii_byte: str = printable
 
 
 def ascii_strings(buf, n=4):

--- a/indxparse/SDS_get_index.py
+++ b/indxparse/SDS_get_index.py
@@ -30,7 +30,6 @@ def main():
     import argparse
     import contextlib
     import mmap
-    import sys
 
     parser = argparse.ArgumentParser(description="Get an SDS record by index.")
     parser.add_argument(

--- a/indxparse/__init__.py
+++ b/indxparse/__init__.py
@@ -3,4 +3,12 @@
 
 __version__ = "1.1.9"
 
-from . import MFT, SDS, BinaryParser, FileMap, Progress, SortedCollection, get_file_info
+from . import (  # noqa: F401
+    MFT,
+    SDS,
+    BinaryParser,
+    FileMap,
+    Progress,
+    SortedCollection,
+    get_file_info,
+)

--- a/indxparse/fuse-mft.py
+++ b/indxparse/fuse-mft.py
@@ -15,7 +15,7 @@ from fuse import FUSE, FuseOSError, Operations, fuse_get_context  # type: ignore
 
 from indxparse.BinaryParser import Mmap
 from indxparse.get_file_info import format_record
-from indxparse.MFT import Cache, MFTEnumerator, MFTTree
+from indxparse.MFT import Cache, MFTEnumerator, MFTRecord, MFTTree
 from indxparse.Progress import ProgressBarProgress
 
 PERMISSION_ALL_READ = int("444", 8)
@@ -116,7 +116,7 @@ class RegularFH(FH):
             return self._record.standard_information.logical_size()
 
 
-def get_meta_for_file(record, path):
+def get_meta_for_file(record: MFTRecord, path: str) -> str:
     """
     Given an MFT record, print out metadata about the relevant file.
     @type record: MFT.MFTRecord
@@ -238,7 +238,8 @@ class MFTFuseOperations(Operations):
             (working_path, special) = explode_special_file(path)
             if special == "meta":
                 node = self._get_node(working_path)
-                record_buf = self._enumerator.get_record_buf(node.get_record_number())
+                # TODO - Check to see if anything further in the control flow relies on a side-effect of this call.
+                _ = self._enumerator.get_record_buf(node.get_record_number())
                 size = len(get_meta_for_file(record, working_path))
         else:
             data_attribute = record.data_attribute()

--- a/indxparse/get_file_info.py
+++ b/indxparse/get_file_info.py
@@ -9,6 +9,7 @@ import array
 import datetime
 import logging
 import re
+from string import printable
 from typing import Any, Dict
 
 from jinja2 import Template
@@ -27,7 +28,7 @@ from indxparse.MFT import (
     StandardInformationFieldDoesNotExist,
 )
 
-ASCII_BYTE = b" !\"#\$%&'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}\\\~"
+ASCII_BYTE: bytes = printable.encode("ascii")
 
 
 def ascii_strings(buf, n=4):

--- a/indxparse/get_file_info.py
+++ b/indxparse/get_file_info.py
@@ -276,7 +276,7 @@ def make_model(record: MFTRecord, path: str) -> Dict[str, Any]:
     return model
 
 
-def format_record(record, path):
+def format_record(record: MFTRecord, path: str) -> str:
     template = Template(
         """\
 MFT Record: {{ record.inode }}

--- a/indxparse/tree_mft.py
+++ b/indxparse/tree_mft.py
@@ -4,12 +4,10 @@
 #   are not subject to US Copyright.
 
 import argparse
-import calendar
 import logging
 import mmap
-from datetime import datetime
 
-from indxparse.MFT import Cache, MFTEnumerator, MFTTree, MFTTreeNode
+from indxparse.MFT import Cache, MFTTree, MFTTreeNode
 
 
 class Mmap(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,12 @@ wx =
 [options.package_data]
 indxparse = py.typed
 
+[flake8]
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
+extend-ignore =
+  E203
+  E501
+
 [isort]
 # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html
 profile = black

--- a/tests/list_mft/out.json
+++ b/tests/list_mft/out.json
@@ -1711,7 +1711,8 @@
             }
         ],
         "active_ascii_strings": [
-            "FILE0"
+            "FILE0",
+            ".\n?E"
         ],
         "active_unicode_strings": [
             "$Secure",


### PR DESCRIPTION
This patch series ends with adding `flake8`[^1] to the CI review done with `pre-commit`, in partial satisfaction of [Issue 38](https://github.com/williballenthin/INDXParse/issues/38).

For the benefit of future use of `git bisect`[^1], patches that fix issues raised by `flake8` are applied before adding `flake8`.

Each patch has a log message documenting its changes.

[^1]: Disclaimer: Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.