### PR TITLE
Expand Python version testing to include 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: 
           - '3.8'
-          - '3.11'
+          - '3.12'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.12 was released on October 2nd.  Recent testing has passed in manual runs on 3.12, so this PR adds 3.12 as part of the regular CI review.

References:
* https://peps.python.org/pep-0693/#schedule